### PR TITLE
Update dates and accepted papers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ assets/libs/
 node_modules/
 vendor
 .idea
+submissions.csv

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
 # Foundation Models for Structured Data
 
-Source Code for the [website](https://icml-structured-fm-workshop.github.io/) of the First Workshop on Foundation Models for Structured Data at the Forty-Second [International Conference on Machine Learning (ICML)](https://icml.cc/), July 2025, Vancouver, Canada.
+Source Code for the [website](https://icml-structured-fm-workshop.github.io/) of the Second Workshop on Foundation Models for Structured Data at the Forty-Third [International Conference on Machine Learning (ICML)](https://icml.cc/), July 2026, Seoul, South Korea.
+
+## Accepted papers
+
+### Preparation
+
+Export the paper list from OpenReview and save it as `submissions.csv` at the repo root.
+
+Create a local Python venv and install the OpenReview Python client:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install openreview-py
+```
+
+### Update accepted papers
+
+To regenerate the accepted-papers bibfile, run:
+
+```bash
+.venv/bin/python scripts/generate_accepted.py --username USERNAME --prompt-password
+```
+
+This reads `submissions.csv`, filters out rejected papers, resolves author names
+via the OpenReview API, and writes `_bibliography/papers.bib`.
+
+Credentials are required unless papers are already public. 
+Use any account with read access to the venue (typically a PC/organizer login).
+

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,7 +2,7 @@
 ---
 @inproceedings{
 abolhasani2026plurel,
-title={{PluRel-to-RDB-PFN}: Schema-Guided Synthetic Relational Pretraining},
+title={PluRel-to-RDB-PFN: Schema-Guided Synthetic Relational Pretraining},
 author={Mohammad Sadeq Abolhasani and Viswanath Ganapathy},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,2 +1,1360 @@
 ---
 ---
+@inproceedings{
+abolhasani2026plurel,
+title={\plurel-to-\rdbpfn: Schema-Guided Synthetic Relational Pretraining},
+author={Mohammad Sadeq Abolhasani and Viswanath Ganapathy},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=RpNvhdvd2v}
+}
+
+@inproceedings{
+orourke2026causal,
+title={A Causal DAG Prior for Synthetic Time-Series Classification Datasets},
+author={Franco Martino O'Rourke and Ana Trisovic and Dimitris Bertsimas},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=A1Al2YF74W}
+}
+
+@inproceedings{
+zhu2026causal,
+title={A Causal Foundation Model for Structure and Outcome Prediction},
+author={Max Zhu and Martino Mansoldo and Ching-Hao Wang and Stefan Groha},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=GOf9c4lOCf}
+}
+
+@inproceedings{
+rautela2026foundation,
+title={A Foundation Model Approach to Particle Accelerator Operational Data},
+author={Mahindra Singh Rautela and Alexander Scheinker},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=sdBsI9MA5a}
+}
+
+@inproceedings{
+jiang2026generative,
+title={A Generative Foundation Model for Heterogeneous Tabular Data},
+author={Xiangjian Jiang and Mingxuan Liu and Nikola Simidjievski and Tassilo Klein and Mateja Jamnik},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=RcsaxrdpfE}
+}
+
+@inproceedings{
+fatehi2026multi,
+title={A Multi-Agent Pipeline for Source-Grounded Synthetic Note Generation from Longitudinal Structured EHR},
+author={Nina Fatehi and Reihaneh Hassanzadeh and Meysam Ghaffari and Animesh Agarwal and Carlos Morato},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FcHLKlJkZl}
+}
+
+@inproceedings{
+gotfrid2026adapt,
+title={Adapt the Data, Not the Model: Input-Space Adaptation for Frozen Time-Series Predictors},
+author={Omer Gotfrid and Dvir Aran and Barak Gahtan and Alex M. Bronstein},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Sc4U6RInKR}
+}
+
+@inproceedings{
+jiang2026agentic,
+title={Agentic Data Intelligence for General Tabular Modeling},
+author={Jun-Peng Jiang and An-Yang Ji and Jia-Yi Zhu and Han-Jia Ye},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=pj1XShgzSv}
+}
+
+@inproceedings{
+wang2026ame,
+title={AME-TS: Anchored Mixture-of-Experts for Time Series Forecasting},
+author={Rui Wang and Renhao Xue and Ray Razi and Huan Song and Hannah R Marlowe},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=NkvfL4hv9c}
+}
+
+@inproceedings{
+pradhan2026apex,
+title={APEX: A Network-Native Time-Series Foundation Model for Forecasting and Anomaly Detection for Wireless Edge Operations},
+author={Swadhin Pradhan and Niloo Bahadori and Peiman Amini},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=38eBW6WYFT}
+}
+
+@inproceedings{
+ramprasath2026are,
+title={Are Tabular Foundation Model Rankings Reliable? A Generalizability Theory Analysis of RelBench and DBInfer},
+author={Dinesh Katupputhur Ramprasath and Tom Palczewski and Joe Meyer and Roshan Reddy Upendra and Minghua Li},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=7jbzkGYag6}
+}
+
+@inproceedings{
+sengupta2026are,
+title={Are Time Series Foundation Models Ready for Oil and Gas Drilling Anomaly Detection?},
+author={Soumyadipta Sengupta and Abdallah Benzine and Sebastiaan Buiting and Ankush Mishra},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Uau401gQnx}
+}
+
+@inproceedings{
+bharadwaj2026atmobench,
+title={AtmoBench: A Large-Scale Multi-Region Benchmark for Air Quality Forecasting with Time Series Foundation Models},
+author={Rishi Bharadwaj and Manik Gupta and Pandarasamy Arjunan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=CUXaSOR9fA}
+}
+
+@inproceedings{
+wang2026auditing,
+title={Auditing and Fixing Economic Validity in Tabular Foundation Models for Discrete Choice},
+author={Yingshuo Wang and Xian Sun and Yanhang Li and Zhichao Fan and Zexin Zhuang},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Tda0qprAXQ}
+}
+
+@inproceedings{
+wu2026balms,
+title={BALMS: Benchmarking Agentic LLMs for Mental Health Sensing},
+author={Yu Yvonne Wu and Arvind Pillai and Yuliang Chen and Sudarshan Regmi and Tess Z Griffin and Michael V. Heinz and Lisa Marsch and Nicholas C. Jacobson and Andrew Campbell},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=NGQyvk68vU}
+}
+
+@inproceedings{
+ossen2026bayesian,
+title={Bayesian Tabular Few-shot Learning with Causal Information},
+author={Ole Ossen and Jake Robertson and Arik Reuter and Magnus Bühler and Lennart Purucker and Frank Hutter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=2yvEiFhNCT}
+}
+
+@inproceedings{
+kuular2026behavioral,
+title={Behavioral Proxy Conditioning for Financial Stress Scenario Generation with a Pretrained Diffusion Model},
+author={Elena Kuular and Junsuk Choe},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=xrwkOUb8kp}
+}
+
+@inproceedings{
+schambach2026benchmarking,
+title={Benchmarking Attention for Tabular Foundation Models},
+author={Maximilian Schambach and Clemens Biehl and Sam Thelin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=rwtcugrpDq}
+}
+
+@inproceedings{
+mohan2026benchmarking,
+title={Benchmarking Multimodal Clinical Foundation Models to Reveal Significant Demographic Disparities},
+author={Milan Mohan and Saketh Lingisetty and Umar Ahmad and Avi Kumar and Shankar Harikrishnan and Sanjana Chamarty and Kevin Zhu},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=h0ffYnBlRo}
+}
+
+@inproceedings{
+seyedzadeh2026benchmarking,
+title={Benchmarking Tabular Foundation Models for Churn Prediction},
+author={Sobhan Seyedzadeh and Mostafa Karimi},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=LtXucHLtiN}
+}
+
+@inproceedings{
+pan2026benchmarking,
+title={Benchmarking Time Series Foundation Models for Electricity Price Forecasting},
+author={Zhenghua Pan and Ahmed Aziz Ezzat},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=6lzVn6W4kg}
+}
+
+@inproceedings{
+keler2026beyond,
+title={Beyond Accuracy: Toward Trustworthy Tabular Foundation Models in Industrial Applications},
+author={Johannes von Keler and Matthias Woehrle and Jan Achterhold and Mark Schillinger and Maria Lyssenko and Luiz Ricardo Douat},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=r3RAi8Kqzl}
+}
+
+@inproceedings{
+le2026beyond,
+title={Beyond Average Leaderboards: When Explicit Graph Priors Help Tabular Foundation Models},
+author={Franck Le and Keith Grueneberg and Erich M Nahum and Vadim Sheinin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=4gmLDG0aGC}
+}
+
+@inproceedings{
+fang2026beyond,
+title={Beyond Task-Specific Classifiers: In-Context Inference for Time Series Classification Foundation Models},
+author={Juntao Fang and Shifeng Xie and Shengbin Nie and Yuhui Ling and Yuming Liu and Zijian Li and Keli Zhang and Lujia Pan and Themis Palpanas and Ruichu Cai},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=HVvARHEA9M}
+}
+
+@inproceedings{
+cho2026biological,
+title={Biological Hallucinations in Time-Series Foundation Models: A Benchmark on High-Frequency Neural Waveforms},
+author={Calvin H. Cho},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=uHquV6aFH3}
+}
+
+@inproceedings{
+gupta2026bootstrap,
+title={Bootstrap-Conditioned Action Selection with Tabular Foundation Models},
+author={Devansh Gupta and Shiv Kumar Tavker and Suchitra Sathyanarayana and Dmitry Efimov and Gitanjali Bhutani and Boris N. Oreshkin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=aBu8Xd6R6s}
+}
+
+@inproceedings{
+lee2026bounded,
+title={Bounded Context Management for Tabular Foundation Models on Stream Learning},
+author={Jinmo Lee and Doyun Choi and Moongi Choi and Jaemin Yoo},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=L94GfndIir}
+}
+
+@inproceedings{
+azevedo2026can,
+title={Can LLMs Use Relational Transformer Embeddings?},
+author={Francisco Galuppo Azevedo and Clarissa Lima Loures},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Z2n7WcIy6j}
+}
+
+@inproceedings{
+ibrahimli2026can,
+title={Can Tabular Foundation Models Predict Algorithm Runtime Distributions?},
+author={Hagverdi Ibrahimli and Steven Adriaensen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=H6t3IZfnqt}
+}
+
+@inproceedings{
+thumm2026causal,
+title={Causal Foundation Models for Time Series based on Prior-Data fitted Networks},
+author={Dennis Thumm and Arik Reuter and Jake Robertson and Shi Bin Hoo and Adrian Weller and Frank Hutter and Ying Chen and Bernhard Schölkopf},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=CAaTQAfq7c}
+}
+
+@inproceedings{
+ham2026causal,
+title={Causal Foundation Models Perform Better without Post-treatment Variables},
+author={Junha Ham and Deokgyu Kim and Doeun Kim and Serjin Kim and Sanghack Lee},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=ULoLF1aOo1}
+}
+
+@inproceedings{
+stith2026causal,
+title={Causal Foundation Models with Continuous Treatments},
+author={Christopher Stith and Medha Barath and Vahid Balazadeh and Jesse C. Cresswell and Rahul G Krishnan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=DzcWAYcR2n}
+}
+
+@inproceedings{
+li2026causaltab,
+title={CausalTab: Pretraining Across Causal Environments for Tabular Causal Discovery},
+author={Zi-Rong Li and Si-Yang Liu and Tian-Zuo Wang and Han-Jia Ye},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=og3UVhP7M1}
+}
+
+@inproceedings{
+correa2026context,
+title={Context Window Failures in Relational Foundation Models},
+author={Denis Oliveira Correa and Francisco Galuppo Azevedo},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=lkuOIfXLwJ}
+}
+
+@inproceedings{
+yan2026context,
+title={Context-Aware Learning Curve Extrapolation with Prior-Data Fitted Networks},
+author={Cheng Yan and Steven Adriaensen and Tom Julian Viering},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=oN4FIXBVeS}
+}
+
+@inproceedings{
+mcdowell2026correcting,
+title={Correcting Class Imbalance in Prior-Data Fitted Networks for Tabular Classification},
+author={Samuel McDowell and Nathan Stromberg and Lalitha Sankar},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=96HA4mxjkH}
+}
+
+@inproceedings{
+tire2026covariance,
+title={Covariance-Aware Transformers for Quadratic Programming and Decision Making},
+author={Kutay Tire and Yufan Zhang and Ege Onur Taga and Samet Oymak},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=XLFOyHaZmq}
+}
+
+@inproceedings{
+wahdany2026dataset,
+title={Dataset Inference for Data Provenance and Privacy Auditing in Tabular Foundation Models},
+author={Dariush Wahdany and Jesse C. Cresswell and Naiqing Guan and Atiyeh Ashari Ghomi and Franziska Boenisch and Adam Dziedzic},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=u2uOPq1u6I}
+}
+
+@inproceedings{
+chagas2026datasynk,
+title={DataSynK: Causal-Symbolic EHR Synthesis for Tabular Foundation Models in Low-Resource Settings},
+author={Eduarda T. C. Chagas and Roberta Viola and Juarez Monteiro and Francisco Galuppo Azevedo and Saulo Fernandes Saturnino and Adriano Veloso},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=3mYAxwt6q7}
+}
+
+@inproceedings{
+balef2026do,
+title={Do Tabular Foundation Models Learn Rules or Memorize Exemplars?},
+author={Amir Rezaei Balef and Mykhailo Koshil and Behzad Nourani-Koliji and Katharina Eggensperger},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=9nCMtYGxQt}
+}
+
+@inproceedings{
+tang2026dr,
+title={Dr-CiK: A Testbed for Foresight-Driven Agents},
+author={Yihong Tang and Andrew Robert Williams and Arjun Ashok and Vincent Zheng and Lijun Sun and Alexandre Drouin and Issam H. Laradji and Étienne Marcotte and Valentina Zantedeschi},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=dHlMWk5X7O}
+}
+
+@inproceedings{
+pawlus2026emergent,
+title={Emergent Temporal Reasoning: Distilling Chain-of-Thought for Zero-Shot Combinatorial Generalization},
+author={Jérémy Pawlus and Philippe Helluy and Svitlana Vyetrenko},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Brk4KtiYoB}
+}
+
+@inproceedings{
+schindler2026enhancing,
+title={Enhancing Tabular Learners with Context-Aware Semantic Embeddings},
+author={Günther Schindler and Maximilian Schambach and Johannes Höhne},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=QArxQg4U71}
+}
+
+@inproceedings{
+tanna2026ensembling,
+title={Ensembling Tabular Foundation Models: A Diversity Ceiling and a Calibration Trap},
+author={Aditya Tanna and Yash Jignesh Desai and Pratinav Seth and Mohamed Bouadi and Nassim Bouarour and Vinay kumar Sankarapu},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FZaZoe67ne}
+}
+
+@inproceedings{
+liu2026evaluating,
+title={Evaluating System 1 vs. 2 Reasoning Approaches for Zero-Shot Time Series Forecasting: A Benchmark and Insights},
+author={Haoxin Liu and Zhiyuan Zhao and Shiduo Li and B. Aditya Prakash},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=8LBHb5N3ns}
+}
+
+@inproceedings{
+chandak2026everyquery,
+title={EveryQuery: Zero-Shot Clinical Prediction via Task-Conditioned Pretraining},
+author={Payal Chandak and Gregory Kondas and Isaac S. Kohane and Matthew B.A. McDermott},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=2Dammq2Yt0}
+}
+
+@inproceedings{
+taga2026evolutionary,
+title={Evolutionary Feature Engineering for Structured Data},
+author={Ege Onur Taga and Yilin Zhuang and Muhammed Emrullah Ildiz and Petros Mol and Abhimanyu Das and Karthik Duraisamy and Samet Oymak},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=EruNY8fps7}
+}
+
+@inproceedings{
+kim2026exploring,
+title={Exploring Differences Between Tabular Enterprise Data and Public Benchmarks},
+author={Myung Jun Kim and Maximilian Schambach and Frank Essenberger and Andre Sres and Johannes Höhne},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=PXSBtjo3Gd}
+}
+
+@inproceedings{
+othman2026factorynet,
+title={FactoryNet: A Large-Scale Dataset toward Industrial Time-Series Foundation Models},
+author={Karim Othman and Jonas Petersen and Matei C. Ignuta-Ciuncanu and Camilla Mazzoleni and Federico Martelli and Gian-Alessandro Lombardi and Riccardo Maggioni and Philipp Christian Petersen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=cLQSnWXOfx}
+}
+
+@inproceedings{
+hasani2026fairopt,
+title={FairOpt-PFN: Amortized Counterfactual Fairness with Optimal Fair Targets},
+author={Enes Hasani and Jake Robertson and Frank Hutter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=M8o7jbKX9P}
+}
+
+@inproceedings{
+rastogi2026feature,
+title={Feature Space Translation Framework for Cross-Device Alignment and Derivation of Clinically Relevant Retinal Biomarkers from Foundation Model Embeddings},
+author={Sparsh Rastogi and Akshat Bakshi and Jidugu Sriharisesh and Imran Razzak and Jatin Bedi and Sahil Thakur},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=wdv1dX1s9w}
+}
+
+@inproceedings{
+polewczyk2026flextab,
+title={FlexTab: Towards a Flexible Encoder-Decoder Architecture for Tabular In-Context Learning},
+author={Marek Polewczyk and Maximilian Schambach and Marco Spinaci and Sam Thelin and Johannes Höhne},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=fOph6xxdyP}
+}
+
+@inproceedings{
+linsky2026forecasting,
+title={Forecasting Food Inflation in Real Time with Tabular Foundation Models},
+author={Mason Linsky},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=kiupx7dsOf}
+}
+
+@inproceedings{
+bellot2026foundation,
+title={Foundation Models for Partial Causal Identification},
+author={Alexis Bellot and Anish Dhir},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=jCbehzZBsk}
+}
+
+@inproceedings{
+li2026foundation,
+title={Foundation Models for Sparse, Multi-Relational Risk Prediction in Global Supply Chains},
+author={Ruohong Li and George Pu and James Nordlund and Prasanth Meiyappan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=W7NIrEh8bI}
+}
+
+@inproceedings{
+ghoroghchian2026foundations,
+title={Foundations without Fundamentals: Zero-Shot Blind Spots in Time Series FMs},
+author={Nafiseh Ghoroghchian and Haipeng Zhang and Shuyi Han and Alex Labach and George Stein},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=iIRdd86Xkr}
+}
+
+@inproceedings{
+afonja2026from,
+title={From Noisy Oracles to Useful Constraints: LLM-Guided Constraint Selection for Synthetic Tabular Data},
+author={Tejumade Afonja and Joscha Cüppers and Mario Fritz},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=1k9oK22A3R}
+}
+
+@inproceedings{
+mishra2026from,
+title={From Time-Series to Text: Multimodal and Agentic Approaches for Automated Drilling Report Generation},
+author={Ankush Mishra and Sebastiaan Buiting and Soumyadipta Sengupta and Abdallah Benzine},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=X1s2qN24kX}
+}
+
+@inproceedings{
+hoseinzade2026frozen,
+title={Frozen LLM Column Embeddings Are Strong Baselines for Column Type Annotation},
+author={Ehsan Hoseinzade and Ke Wang},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=KmlIIDYv8T}
+}
+
+@inproceedings{
+pandey2026gitco,
+title={GITCO: Gated Inference-Time Context Optimization in TSFMs},
+author={Manya Pandey and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=AKHqrrUdWD}
+}
+
+@inproceedings{
+wu2026graph,
+title={Graph In-Context Operator Networks for Generalizable Spatiotemporal Prediction},
+author={Chenghan Wu and Zongmin Yu and Boai Sun and Liu Yang},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=WWriHdAbOm}
+}
+
+@inproceedings{
+laemlin2026grounded,
+title={Grounded Time-Series Anomaly Detection with Compact Multimodal Models and Preference Optimization},
+author={Werner Laemlin and Svitlana Vyetrenko},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FiA40VNrXZ}
+}
+
+@inproceedings{
+petersen2026hepa,
+title={HEPA: A Self-Supervised Horizon-Conditioned Event Predictive Architecture for Time Series},
+author={Jonas Petersen and Gian-Alessandro Lombardi and Riccardo Maggioni and Camilla Mazzoleni and Federico Martelli and Philipp Christian Petersen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=TdpqVBB8na}
+}
+
+@inproceedings{
+dsouza2026hgr,
+title={HGR-TabE: Universal Tabular Embeddings via Maximal Correlation Alignment},
+author={Niharika S. D'Souza and Liane Vogel and Kavitha Srinivas and Sola Shirai and Oktie Hassanzadeh and Horst Samulowitz},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FRj6pclhXE}
+}
+
+@inproceedings{
+nguyen2026hicl,
+title={HICL-TBI: Hyperbolic In-Context Learning for Traumatic Brain Injury Outcome Prediction},
+author={Thai Khanh Nguyen and Thanh-Hai Tran},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=XWF3Sa0xIO}
+}
+
+@inproceedings{
+nie2026hierarchical,
+title={Hierarchical Synthetic Tabular Data Generation: A Hybrid Top-Down and Bottom-Up Framework},
+author={Junfeng Nie and Alvin Jin and Xiaohui Chen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=RiaXCBoWje}
+}
+
+@inproceedings{
+walter2026images,
+title={Images as Tables: In-Context Learning with TabPFN for Low-Data Detection of AI-Generated Images},
+author={Jan Philip Walter and Shashank Agnihotri and Margret Keuper},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=6uEcEWSEfs}
+}
+
+@inproceedings{
+alipour2026impact,
+title={Impact-Driven Event Covariates for Time-Series Foundation Models},
+author={Elham Alipour and xiaoli zhang and Boyang Tom Jin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=8QAsmlh1S4}
+}
+
+@inproceedings{
+gjika2026implicit,
+title={Implicit Reward Alignment For Training Causally-Coherent Tabular Data Generators},
+author={Matea Gjika and Giuseppe Iannone and Luca Sfragara and Pavithra Harsha and Georgia Perakis},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Bei8F38H9r}
+}
+
+@inproceedings{
+dudley2026context,
+title={In-Context Learning Under Regime Change},
+author={Carson Dudley and Xiaofeng Liu and Samet Oymak and Yutong Bi},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=o3dwy5pDAJ}
+}
+
+@inproceedings{
+xu2026inducing,
+title={Inducing Causal Order through Tabular In-Context Learning},
+author={Sascha Xu and Sarah Mameche and Jilles Vreeken},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=U4KiOBxY1X}
+}
+
+@inproceedings{
+miftachov2026inspectable,
+title={Inspectable Tabular Foundation Models via In-Context Kernel Learning},
+author={Ratmir Miftachov and Bruno Charron and Simon Valentin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Q1P83jtxXY}
+}
+
+@inproceedings{
+tai2026language,
+title={Language Pretraining Gives Structured Forecasters a Sequential Prior},
+author={Zhenghan Tai and Alexis Roger and Prateek Humane and Gwen Legate and Andrei Mircea and Vasilii Feofanov and Irina Rish},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=QpTkqxxSiw}
+}
+
+@inproceedings{
+ranjan2026large,
+title={Large-Scale Pretraining unlocks Few-Shot Prediction for Relational Data},
+author={Rishabh Ranjan and Vignesh Kothapalli and Harshvardhan Agarwal and Charilaos I. Kanatsoulis and Roshan Reddy Upendra and Tom Palczewski and Carlos Guestrin and Jure Leskovec},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=oQINTd9din}
+}
+
+@inproceedings{
+dudley2026latent,
+title={Latent Chain-of-Thought Improves Structured-Data Transformers},
+author={Carson Dudley and Samet Oymak},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=L0Mj9fY94c}
+}
+
+@inproceedings{
+xiao2026latent,
+title={Latent Instructions as Context Surrogates: Enhancing Frozen Time Series Forecasters with Instance-Adaptive Prompts},
+author={Zehao Xiao and Shifeng Xie and Lei Zan and Malik Tiomoko and Jianfeng Zhang and Lujia Pan and Keli Zhang and Ievgen Redko},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=YCedi8zejy}
+}
+
+@inproceedings{
+zhou2026learned,
+title={Learned Sequence Representations over Raw Credit Events for Credit-Abuse Scoring},
+author={Tianming Zhou and Jiarui Xu and Nitesh Kumar and Alexander Statnikov},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=8Zxm19jTVM}
+}
+
+@inproceedings{
+felsch2026learning,
+title={Learning to Cool: State Space Models for Smarter Automobile AC Systems},
+author={Forrest Felsch and Sam Mikhak and Taehyung Wang},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=2iVtmlMjxI}
+}
+
+@inproceedings{
+rao2026llm,
+title={LLM-Guided Hard Negative Mining for Structured Product Data Matching},
+author={Manoj Chandrashekar Rao and Mohammed Abraar and Raj Dandekar and Prathamesh Dinesh Joshi and Rajat Dandekar and Sreedath Panat},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=oTxjy6BBcb}
+}
+
+@inproceedings{
+guta2026localized,
+title={Localized TabICLv2: Scaling Tabular In-Context Learning through k-NN},
+author={Beimnet Bekele Guta},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=ddITrUyMTB}
+}
+
+@inproceedings{
+liu2026lookahead,
+title={Lookahead Automated Feature Engineering for Tabular Prediction via Kaggle-Guided Knowledge Transfer},
+author={Si-Yang Liu and Zong-Da Li and Chenming Xu and Han Li and Rui-Qiao Chen and Han-Jia Ye},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FNtlPbGvwc}
+}
+
+@inproceedings{
+tschalzev2026lost,
+title={Lost in Aggregation: How Benchmarks Overlook Irreplaceable Model Strengths},
+author={Andrej Tschalzev and Stefan Lüdtke and Heiner Stuckenschmidt and Christian Bartelt},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=5B1lb8jrgo}
+}
+
+@inproceedings{
+cho2026meg,
+title={MEG-GPT-2: A Generative Foundation Model for MEG with Structured Neural Representations},
+author={SungJun Cho and Chetan Gohil and Oiwi Parker Jones and Mark Woolrich},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=yrVRaS2Ocu}
+}
+
+@inproceedings{
+luo2026memory,
+title={Memory Efficient Tabular Foundation Models},
+author={Shuting Luo and Monika Mikhail Kanaan and Cameron Gordon and Anna Leontjeva and Simon Lucey},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=1Ov4RAWuW4}
+}
+
+@inproceedings{
+nagpal2026mix,
+title={Mix, Don’t Pick: Why Synthetic Corpus Composition Matters for Time Series Foundation Model Pretraining},
+author={Aaryan Nagpal and Debdeep Sanyal and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=ywumgXC5bh}
+}
+
+@inproceedings{
+arazi2026multabench,
+title={MulTaBench: Benchmarking Multimodal Tabular Learning with Text and Image},
+author={Alan Arazi and Eilam Shapira and Shoham Grunblat and Mor Ventura and Elad Hoffer and Gioia Blayer and David Holzmüller and Lennart Purucker and Gaël Varoquaux and Frank Hutter and Roi Reichart},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=r19rlhngOD}
+}
+
+@inproceedings{
+sitani2026multi,
+title={Multi-Task Multimodal Fusion with Tabular Foundation Models for Pertussis Booster Response Prediction},
+author={Divya Sitani},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=iIsQ9SiAxF}
+}
+
+@inproceedings{
+li2026multimodal,
+title={Multimodal Structured Foundation Models for Noisy Documents: A 110M Encoder Where Structure Matches Scale on Clinical Key--Value Generation},
+author={Yingyun Li and Haiyang Qian},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=zROz2mgYql}
+}
+
+@inproceedings{
+lawson2026mutual,
+title={Mutual Information-Guided Corruption for Improved Self-Supervised Representation Learning in Tabular Data},
+author={Michael Lawson and Emerald Sy and Kehui Zhang and Raymond H. Chan and Kannie W. Y. Chan and Rosa H. M. Chan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=T8qbmiE0yZ}
+}
+
+@inproceedings{
+carter2026next,
+title={Next-Token Prediction Enables Scalable Learning of Sleep Physiology},
+author={Jonathan F. Carter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=QVavRSyjmj}
+}
+
+@inproceedings{
+zlyomi2026nonlinear,
+title={Nonlinear RNNs as a Compute Shortcut for Time Series Foundation Models},
+author={Levente Zólyomi and David Stap and Sebastian Böck and Günter Klambauer and Sepp Hochreiter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=tFxw63oxzV}
+}
+
+@inproceedings{
+neto2026objective,
+title={Objective and data-driven Bayesian inference using TabPFN models},
+author={Elias Chaibub Neto},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=YRcXyqoemK}
+}
+
+@inproceedings{
+lowe2026application,
+title={On the Application of Time-Series Foundation Models for Detecting Long-Context Anomalies in Industrial Control Systems},
+author={Alexa Lowe and Clement Fung and Lujo Bauer},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=zKWdTO8ART}
+}
+
+@inproceedings{
+hlskamp2026uncertainty,
+title={On the Uncertainty in Prior-Data Fitted Network Pretraining},
+author={Manuel Hülskamp and Julius Kobialka and Emanuel Sommer and David Rügamer},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=5Shv4Ar4N9}
+}
+
+@inproceedings{
+zhang2026online,
+title={Online Test-Time Adaptation in Tabular Data with Minimal High-Certainty Samples},
+author={Mingming Zhang and Zhiqing Xiao and Junbo Zhao},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=rmpLcZtJ4l}
+}
+
+@inproceedings{
+belligoli2026ophthadt,
+title={OphthaDT: Generative Digital Twins for Forecasting Visual Acuity Trajectories in Ophthalmology},
+author={Pietro Belligoli and Nikita Makarov and Sayedali Shetab Boushehri and Fabian Schmich and Raul Rodriguez-Esteban and Michael Patrick Menden},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=vQeKbsy347}
+}
+
+@inproceedings{
+merchant2026optimizing,
+title={Optimizing Pre-Training of Tabular Foundation Models by Shaping Geometry},
+author={Humzah Merchant and Sriniketh Vangaru and Randall Balestriero},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=IYnHchzvYB}
+}
+
+@inproceedings{
+xu2026parameter,
+title={Parameter-Free Encoders Remain Viable for RDB Foundation Models},
+author={Linjie Xu and David Wipf},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=wRWaegFYMx}
+}
+
+@inproceedings{
+gao2026perturbpfn,
+title={PerturbPFN: Probing the Limits of Synthetic Priors in Perturbation Modelling},
+author={Yuche Gao and José Miguel Hernández-Lobato and Siyuan Guo},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=xTxfxVoUux}
+}
+
+@inproceedings{
+tanna2026pocket,
+title={Pocket Foundation Models: Distilling TFMs into CPU-Ready GBDTs},
+author={Aditya Tanna and Nassim Bouarour and Mohamed Bouadi and Vinay kumar Sankarapu and Pratinav Seth},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=n1TUx8fHpv}
+}
+
+@inproceedings{
+han2026polynomial,
+title={Polynomial Input Preconditioning for Zero-Shot Time Series Forecasting},
+author={Jerry Han and Alex Kawaja and Benjamin Cole and Elad Hazan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=dHnkd1Cxqe}
+}
+
+@inproceedings{
+ostroukhov2026pragma,
+title={PRAGMA: A Foundation Model for Banking Event Sequences},
+author={Maxim Ostroukhov and Ruslan Mikhailov and Vladimir Iashin and Artem Sokolov and Andrei Akshonov and Vitaly Protasov and Dmitrii Beloborodov and Vince Mullin and Roman Enzmann and Georgios Kolovos and Jason Renders and Pavel Nesterov and Anton Repushko},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=9SLZGd9Iur}
+}
+
+@inproceedings{
+yadav2026probing,
+title={Probing Clinical Concepts in an EHR Foundation Model via Sparse Autoencoders},
+author={Shashank Yadav and David M. Routman and Andrew Y. K. Foong},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=8ldqcGf9ra}
+}
+
+@inproceedings{
+capano2026probing,
+title={Probing Memorization of Tabular In-Context Learning},
+author={Francesco Capano and Jonas Böhler},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=7DZ3u0SD4b}
+}
+
+@inproceedings{
+peroni2026rad,
+title={RAD-TFM: Robust and Domain-Adapted Tabular Foundation Models},
+author={Matthew Peroni and Franck Le and Vadim Sheinin},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=5BkHclEOW0}
+}
+
+@inproceedings{
+cheng2026realistic,
+title={Realistic Evaluation of TabPFN v2.5 in Open Environments},
+author={Zi-Jian Cheng and Ziyi Jia and Lan-Zhe Guo},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=qway3qFkUL}
+}
+
+@inproceedings{
+kotawala2026recall,
+title={Recall Residualisation: Decontaminating Foundation-Model Evaluation on Public Time-Series Benchmarks},
+author={Anany Kotawala},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=YCAl9rtW2n}
+}
+
+@inproceedings{
+gupta2026regen,
+title={ReGeN: Reference-Guided Synthetic Multivariate Time Series Generation for Forecasting},
+author={Moulik Gupta and Aaditya Jain and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=sDrP8WsCb3}
+}
+
+@inproceedings{
+shurrab2026retrieval,
+title={Retrieval-Augmented Foundation Model Enhances Risk Prediction Using Electronic Health Records},
+author={Saeed Shurrab and Mariam Al-Omari and Dana El Samad and Farah E. Shamout},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=UMGFi5C19P}
+}
+
+@inproceedings{
+fu2026reverso,
+title={Reverso: Efficient Time Series Foundation Models for Zero-shot Forecasting},
+author={Xinghong Fu and Yanhong Li and GEORGIOS PAPAIOANNOU and Yoon Kim},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=gsuqQs0G0K}
+}
+
+@inproceedings{
+herre2026revisiting,
+title={Revisiting Metafeatures to Explain Model Differences on Tabular Data},
+author={Markus Herre and Andrej Tschalzev and Sascha Marton and Christian Bartelt},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=FJSkVoD4k3}
+}
+
+@inproceedings{
+richards2026scbench,
+title={SCBench: A Testbed for Causal Inference with Time Series Panel Data},
+author={Megan Richards and Saeyoung Rho and Kyunghyun Cho},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=9cluMqZFGA}
+}
+
+@inproceedings{
+sridhar2026semantics,
+title={Semantics or Structure? Auditing Text Sensitivity in Multimodal Time-Series Forecasting},
+author={Karthik Sridhar and Atharva Gupta and Nishant Pradhan and Murari Mandal and Dhruv Kumar and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Lxi62zMl39}
+}
+
+@inproceedings{
+yibo2026should,
+title={Should LLMs Explain Every Time-Series Alert? A Reliability-Routed Audit for Structured Data Monitoring},
+author={WANG Yibo and Shuai Wang and Zhang Ting and Huang Runqing and Tsin Hei Koo and Zhiqiang Cao},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=0KE9OHvEo1}
+}
+
+@inproceedings{
+redhead2026signature,
+title={Signature-Kernel Based Evaluation Metrics for Robust Probabilistic and Tail-Event Forecasting},
+author={Benjamin R Redhead and Thomas L Lee and Peng Gu and Víctor Elvira and Amos Storkey},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=5CJKugZUEF}
+}
+
+@inproceedings{
+raza2026simguard,
+title={SimGuard: Context-Aware Anomaly Filtering via Similarity-Guided Error Detection},
+author={Amir Raza and Mayank Jauhari and Vikash Sharma and Vipul Joshi and Boris N. Oreshkin and Anurag Tripathi},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=nYshRurz2i}
+}
+
+@inproceedings{
+vries2026sohet,
+title={SOHET: Sequence Of Heterogeneous Events Transformer with Self-Supervised Pre-Training},
+author={Kees Jan de Vries and Mustafa Radha and Mathijs de Jong},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=z2Jb4Swqjp}
+}
+
+@inproceedings{
+ztrk2026speedrunning,
+title={Speedrunning Tabular Foundation Model Pretraining},
+author={Salih Bora Öztürk and Alexander Pfefferle and Frank Hutter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=QT1ySCPeW3}
+}
+
+@inproceedings{
+klein2026statistically,
+title={Statistically Indistinguishable, Operationally Distinct: A Formal Barrier for Tabular Foundation Models},
+author={Tassilo Klein and Johannes Hoffart},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=TUYc2XUdwz}
+}
+
+@inproceedings{
+vieyra2026staying,
+title={Staying Alive: Uncensored Survival Analysis with Tabular Foundation Models},
+author={Mariana Vargas Vieyra},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=2EFykQheZD}
+}
+
+@inproceedings{
+kraabel2026structured,
+title={Structured Physical Attributes Enable Efficient Foundation Models for Land-Surface Prediction},
+author={Nicholas Kraabel and Jiangtao Liu and Yuchen Bian and Daniel Kifer and Chaopeng Shen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=vYEpo2F7ty}
+}
+
+@inproceedings{
+qi2026survivalpfn,
+title={SurvivalPFN: Amortizing Survival Prediction via In-Context Bayesian Inference},
+author={Shi-ang Qi and Vahid Balazadeh and Michael Cooper and Russell Greiner and Rahul G Krishnan},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=PDik7bpFhE}
+}
+
+@inproceedings{
+bhm2026survpfn,
+title={SurvPFN: Towards Foundation Models for Survival Predictions},
+author={Samuel Böhm and Lennart Purucker and Frank Hutter and Pascal Schlosser},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=kDEHp7ytr2}
+}
+
+@inproceedings{
+cheng2026symbollm,
+title={SymboLLM-FE: LLM Accelerated Symbolic Regression for Automated Feature Engineering},
+author={Zi-Jian Cheng and Ziyi Jia and Zhi Zhou and Yu-Feng Li and Lan-Zhe Guo},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Lb0pXRiYg8}
+}
+
+@inproceedings{
+cai2026synthetic,
+title={Synthetic Causal Priors for In-Context Time-Series Classification},
+author={Hao-Run Cai and Han-Jia Ye},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=nMRrgMF2S8}
+}
+
+@inproceedings{
+hosseinzadeh2026tabdpt,
+title={TabDPT-Turbo: Efficient In-Context Learning for Tabular Prediction},
+author={Rasa Hosseinzadeh and Alex Labach and Zexin Xue and Shuyi Han and Valentin Thomas and Anthony L. Caterini},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Y00pwFyrHR}
+}
+
+@inproceedings{
+liu2026tablefactory,
+title={TableFactory: Generating Semantically Linked Tabular Data via Multi-Agent Behavioral Simulation},
+author={Mingxuan Liu and Xiangjian Jiang and Johannes Hoffart and Tassilo Klein},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=3bzbWeaL5j}
+}
+
+@inproceedings{
+wahdany2026tabpate,
+title={TabPATE: Differentially Private Tabular In-Context Learning Without Public Data},
+author={Dariush Wahdany and Matthew Jagielski and Jesse C. Cresswell and Adam Dziedzic and Franziska Boenisch},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=Q5iGt2Z0Ql}
+}
+
+@inproceedings{
+tang2026tabpfn,
+title={TabPFN-TSRA: Retrieval-Augmented TabPFN for Time-Series Forecasting},
+author={Zijian Tang and Ying Zhang and Zhenjun Liu and Sibo Cai and Shibin Yue and Meili Zhang},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=pGK4RbJTC9}
+}
+
+@inproceedings{
+cannistraci2026tabular,
+title={Tabular Foundation Models Are Effectively Shallow},
+author={Irene Cannistraci and Julia E Vogt},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=kCnZUf1VYC}
+}
+
+@inproceedings{
+petukhov2026tarpa,
+title={TARPA: Retrieval Priors for Time-Series Foundation Models on Audience Retention},
+author={Dmitriy Petukhov and Nikolai Kharchevnikov and Leon Useinov and Sviatoslav A. Stumpf and Valeria Efimova},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=eaztRkmhlL}
+}
+
+@inproceedings{
+maggioni2026tempo,
+title={TEMPO: Time Series Understanding via Discrete Tokenization},
+author={Riccardo Maggioni},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=U5OBLh3jfZ}
+}
+
+@inproceedings{
+yce2026temporal,
+title={Temporal Feature Extractors in EEG Foundation Models: A Controlled Comparison Including a Pretrained Time-Series Model},
+author={Ayşe Betül Yüce and Chris Joey Leffler and Sarun Varghese and Myra Spiliopoulou and Sebastian Stober},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=oKlirtyeF7}
+}
+
+@inproceedings{
+guo2026text,
+title={Text-Attention Guided In-Context Forecasting for Multimodal Time Series Prediction},
+author={Yuyan Guo and Mingzhe Zhang and Vishwesh Ramanathan and Maryam Motamedi and Nafiseh Ghoroghchian and Shuyi Han and Alex Labach and Anthony L. Caterini and Yi Sui},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=hZgJjZRE4a}
+}
+
+@inproceedings{
+nguyen2026tfm,
+title={TFM-Retouche: A Lightweight Input-Space Adapter for Tabular Foundation Models},
+author={Duong Nguyen and Mohammed Jawhar and Nicolas CHESNEAU},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=P1bvn0jvGX}
+}
+
+@inproceedings{
+longarini2026time,
+title={Time series Foundation Models based on Physics-Informed Synthetic Histories for Cold-Start Photovoltaic Forecasting},
+author={Lorenzo Longarini and Alessandro Rongoni and Simone Silenzi and Emanuele Frontoni and Riccardo Rosati},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=T2msnjOWrh}
+}
+
+@inproceedings{
+roschmann2026tivit,
+title={TiViT: Time Series Representations for Classification Lie Hidden in Pretrained Vision Transformers},
+author={Simon Roschmann and Quentin Bouniot and Vasilii Feofanov and Ievgen Redko and Zeynep Akata},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=49DWDGNGwf}
+}
+
+@inproceedings{
+odonnell2026towards,
+title={Towards Benchmarking Time Series Foundation Models on Native Scientific Data},
+author={Lewis O'Donnell and Arinbjörn Kolbeinsson and Benedikt Kolbeinsson and Marc Peter Deisenroth},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=NtU2gLl4hN}
+}
+
+@inproceedings{
+thumm2026towards,
+title={Towards Continuous-time Causal Foundation Models},
+author={Dennis Thumm and Ruben Wiedemann and Ying Chen},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=iZO7RRZDCC}
+}
+
+@inproceedings{
+zhou2026towards,
+title={Towards Effective LLM Reasoning for Time Series Classification},
+author={Jiahui Zhou and Dan Li and Wenjie Feng and Lin Li and Jian Lou and See-Kiong Ng},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=4rlzjjSTmg}
+}
+
+@inproceedings{
+trkmen2026towards,
+title={Towards Evaluating Data Priors for Tabular Foundation Models},
+author={Zeynep Türkmen and Kürşat Kaya and Alexander Pfefferle and Frank Hutter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=GUDjbVGFc1}
+}
+
+@inproceedings{
+tajjar2026towards,
+title={Towards Pretraining Text Encoders for TabPFN},
+author={Mustafa Tajjar and Alexander Pfefferle and Lennart Purucker and Frank Hutter},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=dA8IZj8R46}
+}
+
+@inproceedings{
+sood2026tradefm,
+title={TradeFM: A Generative Foundation Model for Trade-flow and Market Microstructure},
+author={Srijan Sood and Maxime Kawawa-Beaudan and Daniel Borrajo and Manuela Veloso},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=anK6dppdfa}
+}
+
+@inproceedings{
+kenfack2026training,
+title={Training Fair Tabular Foundation Models},
+author={Patrik Kenfack and Jesse C. Cresswell and Anthony L. Caterini and Samira Ebrahimi Kahou and Ulrich Aïvodji},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=ajIvCEbadL}
+}
+
+@inproceedings{
+sivalingam2026tsquerybench,
+title={TSQueryBench: LLM-as-a-Judge for Time-Series Explanations},
+author={Preetham Sivalingam and Murari Mandal and Dhruv Kumar and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=4zY414Cp3v}
+}
+
+@inproceedings{
+jeon2026vlm,
+title={VLM-Guided Noisy Label Detection for Structured Network Traffic in Low-Resource IDS},
+author={Yuha Jeon and Myung-Sun Baek},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=w82j6qd9Od}
+}
+
+@inproceedings{
+bouadi2026what,
+title={What You Pretrain On Matters: Synthetic Task Distributions Determine Tabular Foundation Model Quality},
+author={Mohamed Bouadi and Nassim Bouarour and Shivam Dubey and Varun Kulkarni and Aditya Tanna and Vinay kumar Sankarapu},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=QfXHxB9VSS}
+}
+
+@inproceedings{
+leeuwen2026when,
+title={When Data Is Scarce: The Strength of the Prior in Tabular Foundation Models},
+author={Florian D. van Leeuwen and Sara van Erp},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=dznQA3JHfI}
+}
+
+@inproceedings{
+shao2026when,
+title={When Forecasting Fails: Overcoming Temporal Correlation Shift in Time Series},
+author={Chen Shao and Zhenyi ZHU and Tobias Käfer},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=r0rUbOXBUE}
+}
+
+@inproceedings{
+eisenberg2026when,
+title={When Simpler ICL Outperforms Pretrained Tabular Foundation Models for RNA Editing},
+author={Ran Eisenberg and Efraim Rahamim and Erez Levanon and Ofir Lindenbaum},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=enXSrwGxRn}
+}
+
+@inproceedings{
+gupta2026where,
+title={Where Computation Lives Inside TabPFN: Causal Localisation of Attention Head Function},
+author={Atharva Gupta and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
+booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
+year={2026},
+url={https://openreview.net/forum?id=LXSawSSeA9}
+}

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,11 +2,12 @@
 ---
 @inproceedings{
 abolhasani2026plurel,
-title={{PLuRel}-to-{RDB-PFN}: Schema-Guided Synthetic Relational Pretraining},
+title={{PluRel-to-RDB-PFN}: Schema-Guided Synthetic Relational Pretraining},
 author={Mohammad Sadeq Abolhasani and Viswanath Ganapathy},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=RpNvhdvd2v}
+url={https://openreview.net/forum?id=RpNvhdvd2v},
+presentation={poster}
 }
 
 @inproceedings{
@@ -15,7 +16,8 @@ title={A Causal DAG Prior for Synthetic Time-Series Classification Datasets},
 author={Franco Martino O'Rourke and Ana Trisovic and Dimitris Bertsimas},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=A1Al2YF74W}
+url={https://openreview.net/forum?id=A1Al2YF74W},
+presentation={poster}
 }
 
 @inproceedings{
@@ -24,7 +26,8 @@ title={A Causal Foundation Model for Structure and Outcome Prediction},
 author={Max Zhu and Martino Mansoldo and Ching-Hao Wang and Stefan Groha},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=GOf9c4lOCf}
+url={https://openreview.net/forum?id=GOf9c4lOCf},
+presentation={poster}
 }
 
 @inproceedings{
@@ -33,7 +36,8 @@ title={A Foundation Model Approach to Particle Accelerator Operational Data},
 author={Mahindra Singh Rautela and Alexander Scheinker},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=sdBsI9MA5a}
+url={https://openreview.net/forum?id=sdBsI9MA5a},
+presentation={poster}
 }
 
 @inproceedings{
@@ -42,7 +46,8 @@ title={A Generative Foundation Model for Heterogeneous Tabular Data},
 author={Xiangjian Jiang and Mingxuan Liu and Nikola Simidjievski and Tassilo Klein and Mateja Jamnik},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=RcsaxrdpfE}
+url={https://openreview.net/forum?id=RcsaxrdpfE},
+presentation={poster}
 }
 
 @inproceedings{
@@ -51,7 +56,8 @@ title={A Multi-Agent Pipeline for Source-Grounded Synthetic Note Generation from
 author={Nina Fatehi and Reihaneh Hassanzadeh and Meysam Ghaffari and Animesh Agarwal and Carlos Morato},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FcHLKlJkZl}
+url={https://openreview.net/forum?id=FcHLKlJkZl},
+presentation={poster}
 }
 
 @inproceedings{
@@ -60,7 +66,8 @@ title={Adapt the Data, Not the Model: Input-Space Adaptation for Frozen Time-Ser
 author={Omer Gotfrid and Dvir Aran and Barak Gahtan and Alex M. Bronstein},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Sc4U6RInKR}
+url={https://openreview.net/forum?id=Sc4U6RInKR},
+presentation={poster}
 }
 
 @inproceedings{
@@ -69,7 +76,8 @@ title={Agentic Data Intelligence for General Tabular Modeling},
 author={Jun-Peng Jiang and An-Yang Ji and Jia-Yi Zhu and Han-Jia Ye},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=pj1XShgzSv}
+url={https://openreview.net/forum?id=pj1XShgzSv},
+presentation={poster}
 }
 
 @inproceedings{
@@ -78,7 +86,8 @@ title={AME-TS: Anchored Mixture-of-Experts for Time Series Forecasting},
 author={Rui Wang and Renhao Xue and Ray Razi and Huan Song and Hannah R Marlowe},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=NkvfL4hv9c}
+url={https://openreview.net/forum?id=NkvfL4hv9c},
+presentation={poster}
 }
 
 @inproceedings{
@@ -87,7 +96,8 @@ title={APEX: A Network-Native Time-Series Foundation Model for Forecasting and A
 author={Swadhin Pradhan and Niloo Bahadori and Peiman Amini},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=38eBW6WYFT}
+url={https://openreview.net/forum?id=38eBW6WYFT},
+presentation={poster}
 }
 
 @inproceedings{
@@ -96,7 +106,8 @@ title={Are Tabular Foundation Model Rankings Reliable? A Generalizability Theory
 author={Dinesh Katupputhur Ramprasath and Tom Palczewski and Joe Meyer and Roshan Reddy Upendra and Minghua Li},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=7jbzkGYag6}
+url={https://openreview.net/forum?id=7jbzkGYag6},
+presentation={poster}
 }
 
 @inproceedings{
@@ -105,7 +116,8 @@ title={Are Time Series Foundation Models Ready for Oil and Gas Drilling Anomaly 
 author={Soumyadipta Sengupta and Abdallah Benzine and Sebastiaan Buiting and Ankush Mishra},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Uau401gQnx}
+url={https://openreview.net/forum?id=Uau401gQnx},
+presentation={poster}
 }
 
 @inproceedings{
@@ -114,7 +126,8 @@ title={AtmoBench: A Large-Scale Multi-Region Benchmark for Air Quality Forecasti
 author={Rishi Bharadwaj and Manik Gupta and Pandarasamy Arjunan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=CUXaSOR9fA}
+url={https://openreview.net/forum?id=CUXaSOR9fA},
+presentation={poster}
 }
 
 @inproceedings{
@@ -123,7 +136,8 @@ title={Auditing and Fixing Economic Validity in Tabular Foundation Models for Di
 author={Yingshuo Wang and Xian Sun and Yanhang Li and Zhichao Fan and Zexin Zhuang},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Tda0qprAXQ}
+url={https://openreview.net/forum?id=Tda0qprAXQ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -132,7 +146,8 @@ title={BALMS: Benchmarking Agentic LLMs for Mental Health Sensing},
 author={Yu Yvonne Wu and Arvind Pillai and Yuliang Chen and Sudarshan Regmi and Tess Z Griffin and Michael V. Heinz and Lisa Marsch and Nicholas C. Jacobson and Andrew Campbell},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=NGQyvk68vU}
+url={https://openreview.net/forum?id=NGQyvk68vU},
+presentation={poster}
 }
 
 @inproceedings{
@@ -141,7 +156,8 @@ title={Bayesian Tabular Few-shot Learning with Causal Information},
 author={Ole Ossen and Jake Robertson and Arik Reuter and Magnus Bühler and Lennart Purucker and Frank Hutter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=2yvEiFhNCT}
+url={https://openreview.net/forum?id=2yvEiFhNCT},
+presentation={poster}
 }
 
 @inproceedings{
@@ -150,7 +166,8 @@ title={Behavioral Proxy Conditioning for Financial Stress Scenario Generation wi
 author={Elena Kuular and Junsuk Choe},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=xrwkOUb8kp}
+url={https://openreview.net/forum?id=xrwkOUb8kp},
+presentation={poster}
 }
 
 @inproceedings{
@@ -159,7 +176,8 @@ title={Benchmarking Attention for Tabular Foundation Models},
 author={Maximilian Schambach and Clemens Biehl and Sam Thelin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=rwtcugrpDq}
+url={https://openreview.net/forum?id=rwtcugrpDq},
+presentation={poster}
 }
 
 @inproceedings{
@@ -168,7 +186,8 @@ title={Benchmarking Multimodal Clinical Foundation Models to Reveal Significant 
 author={Milan Mohan and Saketh Lingisetty and Umar Ahmad and Avi Kumar and Shankar Harikrishnan and Sanjana Chamarty and Kevin Zhu},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=h0ffYnBlRo}
+url={https://openreview.net/forum?id=h0ffYnBlRo},
+presentation={poster}
 }
 
 @inproceedings{
@@ -177,7 +196,8 @@ title={Benchmarking Tabular Foundation Models for Churn Prediction},
 author={Sobhan Seyedzadeh and Mostafa Karimi},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=LtXucHLtiN}
+url={https://openreview.net/forum?id=LtXucHLtiN},
+presentation={poster}
 }
 
 @inproceedings{
@@ -186,7 +206,8 @@ title={Benchmarking Time Series Foundation Models for Electricity Price Forecast
 author={Zhenghua Pan and Ahmed Aziz Ezzat},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=6lzVn6W4kg}
+url={https://openreview.net/forum?id=6lzVn6W4kg},
+presentation={poster}
 }
 
 @inproceedings{
@@ -195,7 +216,8 @@ title={Beyond Accuracy: Toward Trustworthy Tabular Foundation Models in Industri
 author={Johannes von Keler and Matthias Woehrle and Jan Achterhold and Mark Schillinger and Maria Lyssenko and Luiz Ricardo Douat},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=r3RAi8Kqzl}
+url={https://openreview.net/forum?id=r3RAi8Kqzl},
+presentation={poster}
 }
 
 @inproceedings{
@@ -204,7 +226,8 @@ title={Beyond Average Leaderboards: When Explicit Graph Priors Help Tabular Foun
 author={Franck Le and Keith Grueneberg and Erich M Nahum and Vadim Sheinin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=4gmLDG0aGC}
+url={https://openreview.net/forum?id=4gmLDG0aGC},
+presentation={poster}
 }
 
 @inproceedings{
@@ -213,7 +236,8 @@ title={Beyond Task-Specific Classifiers: In-Context Inference for Time Series Cl
 author={Juntao Fang and Shifeng Xie and Shengbin Nie and Yuhui Ling and Yuming Liu and Zijian Li and Keli Zhang and Lujia Pan and Themis Palpanas and Ruichu Cai},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=HVvARHEA9M}
+url={https://openreview.net/forum?id=HVvARHEA9M},
+presentation={poster}
 }
 
 @inproceedings{
@@ -222,7 +246,8 @@ title={Biological Hallucinations in Time-Series Foundation Models: A Benchmark o
 author={Calvin H. Cho},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=uHquV6aFH3}
+url={https://openreview.net/forum?id=uHquV6aFH3},
+presentation={poster}
 }
 
 @inproceedings{
@@ -231,7 +256,8 @@ title={Bootstrap-Conditioned Action Selection with Tabular Foundation Models},
 author={Devansh Gupta and Shiv Kumar Tavker and Suchitra Sathyanarayana and Dmitry Efimov and Gitanjali Bhutani and Boris N. Oreshkin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=aBu8Xd6R6s}
+url={https://openreview.net/forum?id=aBu8Xd6R6s},
+presentation={poster}
 }
 
 @inproceedings{
@@ -240,7 +266,8 @@ title={Bounded Context Management for Tabular Foundation Models on Stream Learni
 author={Jinmo Lee and Doyun Choi and Moongi Choi and Jaemin Yoo},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=L94GfndIir}
+url={https://openreview.net/forum?id=L94GfndIir},
+presentation={oral}
 }
 
 @inproceedings{
@@ -249,7 +276,8 @@ title={Can LLMs Use Relational Transformer Embeddings?},
 author={Francisco Galuppo Azevedo and Clarissa Lima Loures},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Z2n7WcIy6j}
+url={https://openreview.net/forum?id=Z2n7WcIy6j},
+presentation={poster}
 }
 
 @inproceedings{
@@ -258,7 +286,8 @@ title={Can Tabular Foundation Models Predict Algorithm Runtime Distributions?},
 author={Hagverdi Ibrahimli and Steven Adriaensen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=H6t3IZfnqt}
+url={https://openreview.net/forum?id=H6t3IZfnqt},
+presentation={poster}
 }
 
 @inproceedings{
@@ -267,7 +296,8 @@ title={Causal Foundation Models for Time Series based on Prior-Data fitted Netwo
 author={Dennis Thumm and Arik Reuter and Jake Robertson and Shi Bin Hoo and Adrian Weller and Frank Hutter and Ying Chen and Bernhard Schölkopf},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=CAaTQAfq7c}
+url={https://openreview.net/forum?id=CAaTQAfq7c},
+presentation={poster}
 }
 
 @inproceedings{
@@ -276,7 +306,8 @@ title={Causal Foundation Models Perform Better without Post-treatment Variables}
 author={Junha Ham and Deokgyu Kim and Doeun Kim and Serjin Kim and Sanghack Lee},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=ULoLF1aOo1}
+url={https://openreview.net/forum?id=ULoLF1aOo1},
+presentation={poster}
 }
 
 @inproceedings{
@@ -285,7 +316,8 @@ title={Causal Foundation Models with Continuous Treatments},
 author={Christopher Stith and Medha Barath and Vahid Balazadeh and Jesse C. Cresswell and Rahul G Krishnan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=DzcWAYcR2n}
+url={https://openreview.net/forum?id=DzcWAYcR2n},
+presentation={poster}
 }
 
 @inproceedings{
@@ -294,7 +326,8 @@ title={CausalTab: Pretraining Across Causal Environments for Tabular Causal Disc
 author={Zi-Rong Li and Si-Yang Liu and Tian-Zuo Wang and Han-Jia Ye},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=og3UVhP7M1}
+url={https://openreview.net/forum?id=og3UVhP7M1},
+presentation={poster}
 }
 
 @inproceedings{
@@ -303,7 +336,8 @@ title={Context Window Failures in Relational Foundation Models},
 author={Denis Oliveira Correa and Francisco Galuppo Azevedo},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=lkuOIfXLwJ}
+url={https://openreview.net/forum?id=lkuOIfXLwJ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -312,7 +346,8 @@ title={Context-Aware Learning Curve Extrapolation with Prior-Data Fitted Network
 author={Cheng Yan and Steven Adriaensen and Tom Julian Viering},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=oN4FIXBVeS}
+url={https://openreview.net/forum?id=oN4FIXBVeS},
+presentation={poster}
 }
 
 @inproceedings{
@@ -321,7 +356,8 @@ title={Correcting Class Imbalance in Prior-Data Fitted Networks for Tabular Clas
 author={Samuel McDowell and Nathan Stromberg and Lalitha Sankar},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=96HA4mxjkH}
+url={https://openreview.net/forum?id=96HA4mxjkH},
+presentation={poster}
 }
 
 @inproceedings{
@@ -330,7 +366,8 @@ title={Covariance-Aware Transformers for Quadratic Programming and Decision Maki
 author={Kutay Tire and Yufan Zhang and Ege Onur Taga and Samet Oymak},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=XLFOyHaZmq}
+url={https://openreview.net/forum?id=XLFOyHaZmq},
+presentation={poster}
 }
 
 @inproceedings{
@@ -339,7 +376,8 @@ title={Dataset Inference for Data Provenance and Privacy Auditing in Tabular Fou
 author={Dariush Wahdany and Jesse C. Cresswell and Naiqing Guan and Atiyeh Ashari Ghomi and Franziska Boenisch and Adam Dziedzic},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=u2uOPq1u6I}
+url={https://openreview.net/forum?id=u2uOPq1u6I},
+presentation={oral}
 }
 
 @inproceedings{
@@ -348,7 +386,8 @@ title={DataSynK: Causal-Symbolic EHR Synthesis for Tabular Foundation Models in 
 author={Eduarda T. C. Chagas and Roberta Viola and Juarez Monteiro and Francisco Galuppo Azevedo and Saulo Fernandes Saturnino and Adriano Veloso},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=3mYAxwt6q7}
+url={https://openreview.net/forum?id=3mYAxwt6q7},
+presentation={poster}
 }
 
 @inproceedings{
@@ -357,7 +396,8 @@ title={Do Tabular Foundation Models Learn Rules or Memorize Exemplars?},
 author={Amir Rezaei Balef and Mykhailo Koshil and Behzad Nourani-Koliji and Katharina Eggensperger},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=9nCMtYGxQt}
+url={https://openreview.net/forum?id=9nCMtYGxQt},
+presentation={poster}
 }
 
 @inproceedings{
@@ -366,7 +406,8 @@ title={Dr-CiK: A Testbed for Foresight-Driven Agents},
 author={Yihong Tang and Andrew Robert Williams and Arjun Ashok and Vincent Zheng and Lijun Sun and Alexandre Drouin and Issam H. Laradji and Étienne Marcotte and Valentina Zantedeschi},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=dHlMWk5X7O}
+url={https://openreview.net/forum?id=dHlMWk5X7O},
+presentation={poster}
 }
 
 @inproceedings{
@@ -375,7 +416,8 @@ title={Emergent Temporal Reasoning: Distilling Chain-of-Thought for Zero-Shot Co
 author={Jérémy Pawlus and Philippe Helluy and Svitlana Vyetrenko},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Brk4KtiYoB}
+url={https://openreview.net/forum?id=Brk4KtiYoB},
+presentation={poster}
 }
 
 @inproceedings{
@@ -384,7 +426,8 @@ title={Enhancing Tabular Learners with Context-Aware Semantic Embeddings},
 author={Günther Schindler and Maximilian Schambach and Johannes Höhne},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=QArxQg4U71}
+url={https://openreview.net/forum?id=QArxQg4U71},
+presentation={poster}
 }
 
 @inproceedings{
@@ -393,7 +436,8 @@ title={Ensembling Tabular Foundation Models: A Diversity Ceiling and a Calibrati
 author={Aditya Tanna and Yash Jignesh Desai and Pratinav Seth and Mohamed Bouadi and Nassim Bouarour and Vinay kumar Sankarapu},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FZaZoe67ne}
+url={https://openreview.net/forum?id=FZaZoe67ne},
+presentation={poster}
 }
 
 @inproceedings{
@@ -402,7 +446,8 @@ title={Evaluating System 1 vs. 2 Reasoning Approaches for Zero-Shot Time Series 
 author={Haoxin Liu and Zhiyuan Zhao and Shiduo Li and B. Aditya Prakash},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=8LBHb5N3ns}
+url={https://openreview.net/forum?id=8LBHb5N3ns},
+presentation={poster}
 }
 
 @inproceedings{
@@ -411,7 +456,8 @@ title={EveryQuery: Zero-Shot Clinical Prediction via Task-Conditioned Pretrainin
 author={Payal Chandak and Gregory Kondas and Isaac S. Kohane and Matthew B.A. McDermott},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=2Dammq2Yt0}
+url={https://openreview.net/forum?id=2Dammq2Yt0},
+presentation={poster}
 }
 
 @inproceedings{
@@ -420,7 +466,8 @@ title={Evolutionary Feature Engineering for Structured Data},
 author={Ege Onur Taga and Yilin Zhuang and Muhammed Emrullah Ildiz and Petros Mol and Abhimanyu Das and Karthik Duraisamy and Samet Oymak},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=EruNY8fps7}
+url={https://openreview.net/forum?id=EruNY8fps7},
+presentation={poster}
 }
 
 @inproceedings{
@@ -429,7 +476,8 @@ title={Exploring Differences Between Tabular Enterprise Data and Public Benchmar
 author={Myung Jun Kim and Maximilian Schambach and Frank Essenberger and Andre Sres and Johannes Höhne},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=PXSBtjo3Gd}
+url={https://openreview.net/forum?id=PXSBtjo3Gd},
+presentation={poster}
 }
 
 @inproceedings{
@@ -438,7 +486,8 @@ title={FactoryNet: A Large-Scale Dataset toward Industrial Time-Series Foundatio
 author={Karim Othman and Jonas Petersen and Matei C. Ignuta-Ciuncanu and Camilla Mazzoleni and Federico Martelli and Gian-Alessandro Lombardi and Riccardo Maggioni and Philipp Christian Petersen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=cLQSnWXOfx}
+url={https://openreview.net/forum?id=cLQSnWXOfx},
+presentation={poster}
 }
 
 @inproceedings{
@@ -447,7 +496,8 @@ title={FairOpt-PFN: Amortized Counterfactual Fairness with Optimal Fair Targets}
 author={Enes Hasani and Jake Robertson and Frank Hutter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=M8o7jbKX9P}
+url={https://openreview.net/forum?id=M8o7jbKX9P},
+presentation={poster}
 }
 
 @inproceedings{
@@ -456,7 +506,8 @@ title={Feature Space Translation Framework for Cross-Device Alignment and Deriva
 author={Sparsh Rastogi and Akshat Bakshi and Jidugu Sriharisesh and Imran Razzak and Jatin Bedi and Sahil Thakur},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=wdv1dX1s9w}
+url={https://openreview.net/forum?id=wdv1dX1s9w},
+presentation={poster}
 }
 
 @inproceedings{
@@ -465,7 +516,8 @@ title={FlexTab: Towards a Flexible Encoder-Decoder Architecture for Tabular In-C
 author={Marek Polewczyk and Maximilian Schambach and Marco Spinaci and Sam Thelin and Johannes Höhne},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=fOph6xxdyP}
+url={https://openreview.net/forum?id=fOph6xxdyP},
+presentation={poster}
 }
 
 @inproceedings{
@@ -474,7 +526,8 @@ title={Forecasting Food Inflation in Real Time with Tabular Foundation Models},
 author={Mason Linsky},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=kiupx7dsOf}
+url={https://openreview.net/forum?id=kiupx7dsOf},
+presentation={poster}
 }
 
 @inproceedings{
@@ -483,7 +536,8 @@ title={Foundation Models for Partial Causal Identification},
 author={Alexis Bellot and Anish Dhir},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=jCbehzZBsk}
+url={https://openreview.net/forum?id=jCbehzZBsk},
+presentation={poster}
 }
 
 @inproceedings{
@@ -492,7 +546,8 @@ title={Foundation Models for Sparse, Multi-Relational Risk Prediction in Global 
 author={Ruohong Li and George Pu and James Nordlund and Prasanth Meiyappan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=W7NIrEh8bI}
+url={https://openreview.net/forum?id=W7NIrEh8bI},
+presentation={poster}
 }
 
 @inproceedings{
@@ -501,7 +556,8 @@ title={Foundations without Fundamentals: Zero-Shot Blind Spots in Time Series FM
 author={Nafiseh Ghoroghchian and Haipeng Zhang and Shuyi Han and Alex Labach and George Stein},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=iIRdd86Xkr}
+url={https://openreview.net/forum?id=iIRdd86Xkr},
+presentation={oral}
 }
 
 @inproceedings{
@@ -510,7 +566,8 @@ title={From Noisy Oracles to Useful Constraints: LLM-Guided Constraint Selection
 author={Tejumade Afonja and Joscha Cüppers and Mario Fritz},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=1k9oK22A3R}
+url={https://openreview.net/forum?id=1k9oK22A3R},
+presentation={poster}
 }
 
 @inproceedings{
@@ -519,7 +576,8 @@ title={From Time-Series to Text: Multimodal and Agentic Approaches for Automated
 author={Ankush Mishra and Sebastiaan Buiting and Soumyadipta Sengupta and Abdallah Benzine},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=X1s2qN24kX}
+url={https://openreview.net/forum?id=X1s2qN24kX},
+presentation={poster}
 }
 
 @inproceedings{
@@ -528,7 +586,8 @@ title={Frozen LLM Column Embeddings Are Strong Baselines for Column Type Annotat
 author={Ehsan Hoseinzade and Ke Wang},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=KmlIIDYv8T}
+url={https://openreview.net/forum?id=KmlIIDYv8T},
+presentation={poster}
 }
 
 @inproceedings{
@@ -537,7 +596,8 @@ title={GITCO: Gated Inference-Time Context Optimization in TSFMs},
 author={Manya Pandey and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=AKHqrrUdWD}
+url={https://openreview.net/forum?id=AKHqrrUdWD},
+presentation={poster}
 }
 
 @inproceedings{
@@ -546,7 +606,8 @@ title={Graph In-Context Operator Networks for Generalizable Spatiotemporal Predi
 author={Chenghan Wu and Zongmin Yu and Boai Sun and Liu Yang},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=WWriHdAbOm}
+url={https://openreview.net/forum?id=WWriHdAbOm},
+presentation={poster}
 }
 
 @inproceedings{
@@ -555,7 +616,8 @@ title={Grounded Time-Series Anomaly Detection with Compact Multimodal Models and
 author={Werner Laemlin and Svitlana Vyetrenko},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FiA40VNrXZ}
+url={https://openreview.net/forum?id=FiA40VNrXZ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -564,7 +626,8 @@ title={HEPA: A Self-Supervised Horizon-Conditioned Event Predictive Architecture
 author={Jonas Petersen and Gian-Alessandro Lombardi and Riccardo Maggioni and Camilla Mazzoleni and Federico Martelli and Philipp Christian Petersen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=TdpqVBB8na}
+url={https://openreview.net/forum?id=TdpqVBB8na},
+presentation={oral}
 }
 
 @inproceedings{
@@ -573,7 +636,8 @@ title={HGR-TabE: Universal Tabular Embeddings via Maximal Correlation Alignment}
 author={Niharika S. D'Souza and Liane Vogel and Kavitha Srinivas and Sola Shirai and Oktie Hassanzadeh and Horst Samulowitz},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FRj6pclhXE}
+url={https://openreview.net/forum?id=FRj6pclhXE},
+presentation={poster}
 }
 
 @inproceedings{
@@ -582,7 +646,8 @@ title={HICL-TBI: Hyperbolic In-Context Learning for Traumatic Brain Injury Outco
 author={Thai Khanh Nguyen and Thanh-Hai Tran},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=XWF3Sa0xIO}
+url={https://openreview.net/forum?id=XWF3Sa0xIO},
+presentation={poster}
 }
 
 @inproceedings{
@@ -591,7 +656,8 @@ title={Hierarchical Synthetic Tabular Data Generation: A Hybrid Top-Down and Bot
 author={Junfeng Nie and Alvin Jin and Xiaohui Chen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=RiaXCBoWje}
+url={https://openreview.net/forum?id=RiaXCBoWje},
+presentation={poster}
 }
 
 @inproceedings{
@@ -600,7 +666,8 @@ title={Images as Tables: In-Context Learning with TabPFN for Low-Data Detection 
 author={Jan Philip Walter and Shashank Agnihotri and Margret Keuper},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=6uEcEWSEfs}
+url={https://openreview.net/forum?id=6uEcEWSEfs},
+presentation={oral}
 }
 
 @inproceedings{
@@ -609,7 +676,8 @@ title={Impact-Driven Event Covariates for Time-Series Foundation Models},
 author={Elham Alipour and xiaoli zhang and Boyang Tom Jin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=8QAsmlh1S4}
+url={https://openreview.net/forum?id=8QAsmlh1S4},
+presentation={poster}
 }
 
 @inproceedings{
@@ -618,7 +686,8 @@ title={Implicit Reward Alignment For Training Causally-Coherent Tabular Data Gen
 author={Matea Gjika and Giuseppe Iannone and Luca Sfragara and Pavithra Harsha and Georgia Perakis},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Bei8F38H9r}
+url={https://openreview.net/forum?id=Bei8F38H9r},
+presentation={poster}
 }
 
 @inproceedings{
@@ -627,7 +696,8 @@ title={In-Context Learning Under Regime Change},
 author={Carson Dudley and Xiaofeng Liu and Samet Oymak and Yutong Bi},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=o3dwy5pDAJ}
+url={https://openreview.net/forum?id=o3dwy5pDAJ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -636,7 +706,8 @@ title={Inducing Causal Order through Tabular In-Context Learning},
 author={Sascha Xu and Sarah Mameche and Jilles Vreeken},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=U4KiOBxY1X}
+url={https://openreview.net/forum?id=U4KiOBxY1X},
+presentation={poster}
 }
 
 @inproceedings{
@@ -645,7 +716,8 @@ title={Inspectable Tabular Foundation Models via In-Context Kernel Learning},
 author={Ratmir Miftachov and Bruno Charron and Simon Valentin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Q1P83jtxXY}
+url={https://openreview.net/forum?id=Q1P83jtxXY},
+presentation={poster}
 }
 
 @inproceedings{
@@ -654,7 +726,8 @@ title={Language Pretraining Gives Structured Forecasters a Sequential Prior},
 author={Zhenghan Tai and Alexis Roger and Prateek Humane and Gwen Legate and Andrei Mircea and Vasilii Feofanov and Irina Rish},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=QpTkqxxSiw}
+url={https://openreview.net/forum?id=QpTkqxxSiw},
+presentation={poster}
 }
 
 @inproceedings{
@@ -663,7 +736,8 @@ title={Large-Scale Pretraining unlocks Few-Shot Prediction for Relational Data},
 author={Rishabh Ranjan and Vignesh Kothapalli and Harshvardhan Agarwal and Charilaos I. Kanatsoulis and Roshan Reddy Upendra and Tom Palczewski and Carlos Guestrin and Jure Leskovec},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=oQINTd9din}
+url={https://openreview.net/forum?id=oQINTd9din},
+presentation={poster}
 }
 
 @inproceedings{
@@ -672,7 +746,8 @@ title={Latent Chain-of-Thought Improves Structured-Data Transformers},
 author={Carson Dudley and Samet Oymak},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=L0Mj9fY94c}
+url={https://openreview.net/forum?id=L0Mj9fY94c},
+presentation={poster}
 }
 
 @inproceedings{
@@ -681,7 +756,8 @@ title={Latent Instructions as Context Surrogates: Enhancing Frozen Time Series F
 author={Zehao Xiao and Shifeng Xie and Lei Zan and Malik Tiomoko and Jianfeng Zhang and Lujia Pan and Keli Zhang and Ievgen Redko},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=YCedi8zejy}
+url={https://openreview.net/forum?id=YCedi8zejy},
+presentation={oral}
 }
 
 @inproceedings{
@@ -690,7 +766,8 @@ title={Learned Sequence Representations over Raw Credit Events for Credit-Abuse 
 author={Tianming Zhou and Jiarui Xu and Nitesh Kumar and Alexander Statnikov},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=8Zxm19jTVM}
+url={https://openreview.net/forum?id=8Zxm19jTVM},
+presentation={poster}
 }
 
 @inproceedings{
@@ -699,7 +776,8 @@ title={Learning to Cool: State Space Models for Smarter Automobile AC Systems},
 author={Forrest Felsch and Sam Mikhak and Taehyung Wang},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=2iVtmlMjxI}
+url={https://openreview.net/forum?id=2iVtmlMjxI},
+presentation={poster}
 }
 
 @inproceedings{
@@ -708,7 +786,8 @@ title={LLM-Guided Hard Negative Mining for Structured Product Data Matching},
 author={Manoj Chandrashekar Rao and Mohammed Abraar and Raj Dandekar and Prathamesh Dinesh Joshi and Rajat Dandekar and Sreedath Panat},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=oTxjy6BBcb}
+url={https://openreview.net/forum?id=oTxjy6BBcb},
+presentation={poster}
 }
 
 @inproceedings{
@@ -717,7 +796,8 @@ title={Localized TabICLv2: Scaling Tabular In-Context Learning through k-NN},
 author={Beimnet Bekele Guta},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=ddITrUyMTB}
+url={https://openreview.net/forum?id=ddITrUyMTB},
+presentation={poster}
 }
 
 @inproceedings{
@@ -726,7 +806,8 @@ title={Lookahead Automated Feature Engineering for Tabular Prediction via Kaggle
 author={Si-Yang Liu and Zong-Da Li and Chenming Xu and Han Li and Rui-Qiao Chen and Han-Jia Ye},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FNtlPbGvwc}
+url={https://openreview.net/forum?id=FNtlPbGvwc},
+presentation={poster}
 }
 
 @inproceedings{
@@ -735,7 +816,8 @@ title={Lost in Aggregation: How Benchmarks Overlook Irreplaceable Model Strength
 author={Andrej Tschalzev and Stefan Lüdtke and Heiner Stuckenschmidt and Christian Bartelt},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=5B1lb8jrgo}
+url={https://openreview.net/forum?id=5B1lb8jrgo},
+presentation={poster}
 }
 
 @inproceedings{
@@ -744,7 +826,8 @@ title={MEG-GPT-2: A Generative Foundation Model for MEG with Structured Neural R
 author={SungJun Cho and Chetan Gohil and Oiwi Parker Jones and Mark Woolrich},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=yrVRaS2Ocu}
+url={https://openreview.net/forum?id=yrVRaS2Ocu},
+presentation={poster}
 }
 
 @inproceedings{
@@ -753,7 +836,8 @@ title={Memory Efficient Tabular Foundation Models},
 author={Shuting Luo and Monika Mikhail Kanaan and Cameron Gordon and Anna Leontjeva and Simon Lucey},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=1Ov4RAWuW4}
+url={https://openreview.net/forum?id=1Ov4RAWuW4},
+presentation={poster}
 }
 
 @inproceedings{
@@ -762,7 +846,8 @@ title={Mix, Don’t Pick: Why Synthetic Corpus Composition Matters for Time Seri
 author={Aaryan Nagpal and Debdeep Sanyal and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=ywumgXC5bh}
+url={https://openreview.net/forum?id=ywumgXC5bh},
+presentation={poster}
 }
 
 @inproceedings{
@@ -771,7 +856,8 @@ title={MulTaBench: Benchmarking Multimodal Tabular Learning with Text and Image}
 author={Alan Arazi and Eilam Shapira and Shoham Grunblat and Mor Ventura and Elad Hoffer and Gioia Blayer and David Holzmüller and Lennart Purucker and Gaël Varoquaux and Frank Hutter and Roi Reichart},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=r19rlhngOD}
+url={https://openreview.net/forum?id=r19rlhngOD},
+presentation={poster}
 }
 
 @inproceedings{
@@ -780,7 +866,8 @@ title={Multi-Task Multimodal Fusion with Tabular Foundation Models for Pertussis
 author={Divya Sitani},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=iIsQ9SiAxF}
+url={https://openreview.net/forum?id=iIsQ9SiAxF},
+presentation={poster}
 }
 
 @inproceedings{
@@ -789,7 +876,8 @@ title={Multimodal Structured Foundation Models for Noisy Documents: A 110M Encod
 author={Yingyun Li and Haiyang Qian},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=zROz2mgYql}
+url={https://openreview.net/forum?id=zROz2mgYql},
+presentation={poster}
 }
 
 @inproceedings{
@@ -798,7 +886,8 @@ title={Mutual Information-Guided Corruption for Improved Self-Supervised Represe
 author={Michael Lawson and Emerald Sy and Kehui Zhang and Raymond H. Chan and Kannie W. Y. Chan and Rosa H. M. Chan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=T8qbmiE0yZ}
+url={https://openreview.net/forum?id=T8qbmiE0yZ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -807,7 +896,8 @@ title={Next-Token Prediction Enables Scalable Learning of Sleep Physiology},
 author={Jonathan F. Carter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=QVavRSyjmj}
+url={https://openreview.net/forum?id=QVavRSyjmj},
+presentation={poster}
 }
 
 @inproceedings{
@@ -816,7 +906,8 @@ title={Nonlinear RNNs as a Compute Shortcut for Time Series Foundation Models},
 author={Levente Zólyomi and David Stap and Sebastian Böck and Günter Klambauer and Sepp Hochreiter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=tFxw63oxzV}
+url={https://openreview.net/forum?id=tFxw63oxzV},
+presentation={poster}
 }
 
 @inproceedings{
@@ -825,7 +916,8 @@ title={Objective and data-driven Bayesian inference using TabPFN models},
 author={Elias Chaibub Neto},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=YRcXyqoemK}
+url={https://openreview.net/forum?id=YRcXyqoemK},
+presentation={poster}
 }
 
 @inproceedings{
@@ -834,7 +926,8 @@ title={On the Application of Time-Series Foundation Models for Detecting Long-Co
 author={Alexa Lowe and Clement Fung and Lujo Bauer},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=zKWdTO8ART}
+url={https://openreview.net/forum?id=zKWdTO8ART},
+presentation={poster}
 }
 
 @inproceedings{
@@ -843,7 +936,8 @@ title={On the Uncertainty in Prior-Data Fitted Network Pretraining},
 author={Manuel Hülskamp and Julius Kobialka and Emanuel Sommer and David Rügamer},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=5Shv4Ar4N9}
+url={https://openreview.net/forum?id=5Shv4Ar4N9},
+presentation={poster}
 }
 
 @inproceedings{
@@ -852,7 +946,8 @@ title={Online Test-Time Adaptation in Tabular Data with Minimal High-Certainty S
 author={Mingming Zhang and Zhiqing Xiao and Junbo Zhao},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=rmpLcZtJ4l}
+url={https://openreview.net/forum?id=rmpLcZtJ4l},
+presentation={poster}
 }
 
 @inproceedings{
@@ -861,7 +956,8 @@ title={OphthaDT: Generative Digital Twins for Forecasting Visual Acuity Trajecto
 author={Pietro Belligoli and Nikita Makarov and Sayedali Shetab Boushehri and Fabian Schmich and Raul Rodriguez-Esteban and Michael Patrick Menden},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=vQeKbsy347}
+url={https://openreview.net/forum?id=vQeKbsy347},
+presentation={poster}
 }
 
 @inproceedings{
@@ -870,7 +966,8 @@ title={Optimizing Pre-Training of Tabular Foundation Models by Shaping Geometry}
 author={Humzah Merchant and Sriniketh Vangaru and Randall Balestriero},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=IYnHchzvYB}
+url={https://openreview.net/forum?id=IYnHchzvYB},
+presentation={poster}
 }
 
 @inproceedings{
@@ -879,7 +976,8 @@ title={Parameter-Free Encoders Remain Viable for RDB Foundation Models},
 author={Linjie Xu and David Wipf},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=wRWaegFYMx}
+url={https://openreview.net/forum?id=wRWaegFYMx},
+presentation={poster}
 }
 
 @inproceedings{
@@ -888,7 +986,8 @@ title={PerturbPFN: Probing the Limits of Synthetic Priors in Perturbation Modell
 author={Yuche Gao and José Miguel Hernández-Lobato and Siyuan Guo},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=xTxfxVoUux}
+url={https://openreview.net/forum?id=xTxfxVoUux},
+presentation={poster}
 }
 
 @inproceedings{
@@ -897,7 +996,8 @@ title={Pocket Foundation Models: Distilling TFMs into CPU-Ready GBDTs},
 author={Aditya Tanna and Nassim Bouarour and Mohamed Bouadi and Vinay kumar Sankarapu and Pratinav Seth},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=n1TUx8fHpv}
+url={https://openreview.net/forum?id=n1TUx8fHpv},
+presentation={poster}
 }
 
 @inproceedings{
@@ -906,7 +1006,8 @@ title={Polynomial Input Preconditioning for Zero-Shot Time Series Forecasting},
 author={Jerry Han and Alex Kawaja and Benjamin Cole and Elad Hazan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=dHnkd1Cxqe}
+url={https://openreview.net/forum?id=dHnkd1Cxqe},
+presentation={poster}
 }
 
 @inproceedings{
@@ -915,7 +1016,8 @@ title={PRAGMA: A Foundation Model for Banking Event Sequences},
 author={Maxim Ostroukhov and Ruslan Mikhailov and Vladimir Iashin and Artem Sokolov and Andrei Akshonov and Vitaly Protasov and Dmitrii Beloborodov and Vince Mullin and Roman Enzmann and Georgios Kolovos and Jason Renders and Pavel Nesterov and Anton Repushko},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=9SLZGd9Iur}
+url={https://openreview.net/forum?id=9SLZGd9Iur},
+presentation={poster}
 }
 
 @inproceedings{
@@ -924,7 +1026,8 @@ title={Probing Clinical Concepts in an EHR Foundation Model via Sparse Autoencod
 author={Shashank Yadav and David M. Routman and Andrew Y. K. Foong},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=8ldqcGf9ra}
+url={https://openreview.net/forum?id=8ldqcGf9ra},
+presentation={poster}
 }
 
 @inproceedings{
@@ -933,7 +1036,8 @@ title={Probing Memorization of Tabular In-Context Learning},
 author={Francesco Capano and Jonas Böhler},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=7DZ3u0SD4b}
+url={https://openreview.net/forum?id=7DZ3u0SD4b},
+presentation={poster}
 }
 
 @inproceedings{
@@ -942,7 +1046,8 @@ title={RAD-TFM: Robust and Domain-Adapted Tabular Foundation Models},
 author={Matthew Peroni and Franck Le and Vadim Sheinin},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=5BkHclEOW0}
+url={https://openreview.net/forum?id=5BkHclEOW0},
+presentation={poster}
 }
 
 @inproceedings{
@@ -951,7 +1056,8 @@ title={Realistic Evaluation of TabPFN v2.5 in Open Environments},
 author={Zi-Jian Cheng and Ziyi Jia and Lan-Zhe Guo},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=qway3qFkUL}
+url={https://openreview.net/forum?id=qway3qFkUL},
+presentation={poster}
 }
 
 @inproceedings{
@@ -960,7 +1066,8 @@ title={Recall Residualisation: Decontaminating Foundation-Model Evaluation on Pu
 author={Anany Kotawala},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=YCAl9rtW2n}
+url={https://openreview.net/forum?id=YCAl9rtW2n},
+presentation={poster}
 }
 
 @inproceedings{
@@ -969,7 +1076,8 @@ title={ReGeN: Reference-Guided Synthetic Multivariate Time Series Generation for
 author={Moulik Gupta and Aaditya Jain and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=sDrP8WsCb3}
+url={https://openreview.net/forum?id=sDrP8WsCb3},
+presentation={poster}
 }
 
 @inproceedings{
@@ -978,7 +1086,8 @@ title={Retrieval-Augmented Foundation Model Enhances Risk Prediction Using Elect
 author={Saeed Shurrab and Mariam Al-Omari and Dana El Samad and Farah E. Shamout},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=UMGFi5C19P}
+url={https://openreview.net/forum?id=UMGFi5C19P},
+presentation={poster}
 }
 
 @inproceedings{
@@ -987,7 +1096,8 @@ title={Reverso: Efficient Time Series Foundation Models for Zero-shot Forecastin
 author={Xinghong Fu and Yanhong Li and GEORGIOS PAPAIOANNOU and Yoon Kim},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=gsuqQs0G0K}
+url={https://openreview.net/forum?id=gsuqQs0G0K},
+presentation={poster}
 }
 
 @inproceedings{
@@ -996,7 +1106,8 @@ title={Revisiting Metafeatures to Explain Model Differences on Tabular Data},
 author={Markus Herre and Andrej Tschalzev and Sascha Marton and Christian Bartelt},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=FJSkVoD4k3}
+url={https://openreview.net/forum?id=FJSkVoD4k3},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1005,7 +1116,8 @@ title={SCBench: A Testbed for Causal Inference with Time Series Panel Data},
 author={Megan Richards and Saeyoung Rho and Kyunghyun Cho},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=9cluMqZFGA}
+url={https://openreview.net/forum?id=9cluMqZFGA},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1014,7 +1126,8 @@ title={Semantics or Structure? Auditing Text Sensitivity in Multimodal Time-Seri
 author={Karthik Sridhar and Atharva Gupta and Nishant Pradhan and Murari Mandal and Dhruv Kumar and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Lxi62zMl39}
+url={https://openreview.net/forum?id=Lxi62zMl39},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1023,7 +1136,8 @@ title={Should LLMs Explain Every Time-Series Alert? A Reliability-Routed Audit f
 author={WANG Yibo and Shuai Wang and Zhang Ting and Huang Runqing and Tsin Hei Koo and Zhiqiang Cao},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=0KE9OHvEo1}
+url={https://openreview.net/forum?id=0KE9OHvEo1},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1032,7 +1146,8 @@ title={Signature-Kernel Based Evaluation Metrics for Robust Probabilistic and Ta
 author={Benjamin R Redhead and Thomas L Lee and Peng Gu and Víctor Elvira and Amos Storkey},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=5CJKugZUEF}
+url={https://openreview.net/forum?id=5CJKugZUEF},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1041,7 +1156,8 @@ title={SimGuard: Context-Aware Anomaly Filtering via Similarity-Guided Error Det
 author={Amir Raza and Mayank Jauhari and Vikash Sharma and Vipul Joshi and Boris N. Oreshkin and Anurag Tripathi},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=nYshRurz2i}
+url={https://openreview.net/forum?id=nYshRurz2i},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1050,7 +1166,8 @@ title={SOHET: Sequence Of Heterogeneous Events Transformer with Self-Supervised 
 author={Kees Jan de Vries and Mustafa Radha and Mathijs de Jong},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=z2Jb4Swqjp}
+url={https://openreview.net/forum?id=z2Jb4Swqjp},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1059,7 +1176,8 @@ title={Speedrunning Tabular Foundation Model Pretraining},
 author={Salih Bora Öztürk and Alexander Pfefferle and Frank Hutter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=QT1ySCPeW3}
+url={https://openreview.net/forum?id=QT1ySCPeW3},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1068,7 +1186,8 @@ title={Statistically Indistinguishable, Operationally Distinct: A Formal Barrier
 author={Tassilo Klein and Johannes Hoffart},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=TUYc2XUdwz}
+url={https://openreview.net/forum?id=TUYc2XUdwz},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1077,7 +1196,8 @@ title={Staying Alive: Uncensored Survival Analysis with Tabular Foundation Model
 author={Mariana Vargas Vieyra},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=2EFykQheZD}
+url={https://openreview.net/forum?id=2EFykQheZD},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1086,7 +1206,8 @@ title={Structured Physical Attributes Enable Efficient Foundation Models for Lan
 author={Nicholas Kraabel and Jiangtao Liu and Yuchen Bian and Daniel Kifer and Chaopeng Shen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=vYEpo2F7ty}
+url={https://openreview.net/forum?id=vYEpo2F7ty},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1095,7 +1216,8 @@ title={SurvivalPFN: Amortizing Survival Prediction via In-Context Bayesian Infer
 author={Shi-ang Qi and Vahid Balazadeh and Michael Cooper and Russell Greiner and Rahul G Krishnan},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=PDik7bpFhE}
+url={https://openreview.net/forum?id=PDik7bpFhE},
+presentation={oral}
 }
 
 @inproceedings{
@@ -1104,7 +1226,8 @@ title={SurvPFN: Towards Foundation Models for Survival Predictions},
 author={Samuel Böhm and Lennart Purucker and Frank Hutter and Pascal Schlosser},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=kDEHp7ytr2}
+url={https://openreview.net/forum?id=kDEHp7ytr2},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1113,7 +1236,8 @@ title={SymboLLM-FE: LLM Accelerated Symbolic Regression for Automated Feature En
 author={Zi-Jian Cheng and Ziyi Jia and Zhi Zhou and Yu-Feng Li and Lan-Zhe Guo},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Lb0pXRiYg8}
+url={https://openreview.net/forum?id=Lb0pXRiYg8},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1122,7 +1246,8 @@ title={Synthetic Causal Priors for In-Context Time-Series Classification},
 author={Hao-Run Cai and Han-Jia Ye},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=nMRrgMF2S8}
+url={https://openreview.net/forum?id=nMRrgMF2S8},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1131,7 +1256,8 @@ title={TabDPT-Turbo: Efficient In-Context Learning for Tabular Prediction},
 author={Rasa Hosseinzadeh and Alex Labach and Zexin Xue and Shuyi Han and Valentin Thomas and Anthony L. Caterini},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Y00pwFyrHR}
+url={https://openreview.net/forum?id=Y00pwFyrHR},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1140,7 +1266,8 @@ title={TableFactory: Generating Semantically Linked Tabular Data via Multi-Agent
 author={Mingxuan Liu and Xiangjian Jiang and Johannes Hoffart and Tassilo Klein},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=3bzbWeaL5j}
+url={https://openreview.net/forum?id=3bzbWeaL5j},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1149,7 +1276,8 @@ title={TabPATE: Differentially Private Tabular In-Context Learning Without Publi
 author={Dariush Wahdany and Matthew Jagielski and Jesse C. Cresswell and Adam Dziedzic and Franziska Boenisch},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=Q5iGt2Z0Ql}
+url={https://openreview.net/forum?id=Q5iGt2Z0Ql},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1158,7 +1286,8 @@ title={TabPFN-TSRA: Retrieval-Augmented TabPFN for Time-Series Forecasting},
 author={Zijian Tang and Ying Zhang and Zhenjun Liu and Sibo Cai and Shibin Yue and Meili Zhang},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=pGK4RbJTC9}
+url={https://openreview.net/forum?id=pGK4RbJTC9},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1167,7 +1296,8 @@ title={Tabular Foundation Models Are Effectively Shallow},
 author={Irene Cannistraci and Julia E Vogt},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=kCnZUf1VYC}
+url={https://openreview.net/forum?id=kCnZUf1VYC},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1176,7 +1306,8 @@ title={TARPA: Retrieval Priors for Time-Series Foundation Models on Audience Ret
 author={Dmitriy Petukhov and Nikolai Kharchevnikov and Leon Useinov and Sviatoslav A. Stumpf and Valeria Efimova},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=eaztRkmhlL}
+url={https://openreview.net/forum?id=eaztRkmhlL},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1185,7 +1316,8 @@ title={TEMPO: Time Series Understanding via Discrete Tokenization},
 author={Riccardo Maggioni},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=U5OBLh3jfZ}
+url={https://openreview.net/forum?id=U5OBLh3jfZ},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1194,7 +1326,8 @@ title={Temporal Feature Extractors in EEG Foundation Models: A Controlled Compar
 author={Ayşe Betül Yüce and Chris Joey Leffler and Sarun Varghese and Myra Spiliopoulou and Sebastian Stober},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=oKlirtyeF7}
+url={https://openreview.net/forum?id=oKlirtyeF7},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1203,7 +1336,8 @@ title={Text-Attention Guided In-Context Forecasting for Multimodal Time Series P
 author={Yuyan Guo and Mingzhe Zhang and Vishwesh Ramanathan and Maryam Motamedi and Nafiseh Ghoroghchian and Shuyi Han and Alex Labach and Anthony L. Caterini and Yi Sui},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=hZgJjZRE4a}
+url={https://openreview.net/forum?id=hZgJjZRE4a},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1212,7 +1346,8 @@ title={TFM-Retouche: A Lightweight Input-Space Adapter for Tabular Foundation Mo
 author={Duong Nguyen and Mohammed Jawhar and Nicolas CHESNEAU},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=P1bvn0jvGX}
+url={https://openreview.net/forum?id=P1bvn0jvGX},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1221,7 +1356,8 @@ title={Time series Foundation Models based on Physics-Informed Synthetic Histori
 author={Lorenzo Longarini and Alessandro Rongoni and Simone Silenzi and Emanuele Frontoni and Riccardo Rosati},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=T2msnjOWrh}
+url={https://openreview.net/forum?id=T2msnjOWrh},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1230,7 +1366,8 @@ title={TiViT: Time Series Representations for Classification Lie Hidden in Pretr
 author={Simon Roschmann and Quentin Bouniot and Vasilii Feofanov and Ievgen Redko and Zeynep Akata},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=49DWDGNGwf}
+url={https://openreview.net/forum?id=49DWDGNGwf},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1239,7 +1376,8 @@ title={Towards Benchmarking Time Series Foundation Models on Native Scientific D
 author={Lewis O'Donnell and Arinbjörn Kolbeinsson and Benedikt Kolbeinsson and Marc Peter Deisenroth},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=NtU2gLl4hN}
+url={https://openreview.net/forum?id=NtU2gLl4hN},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1248,7 +1386,8 @@ title={Towards Continuous-time Causal Foundation Models},
 author={Dennis Thumm and Ruben Wiedemann and Ying Chen},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=iZO7RRZDCC}
+url={https://openreview.net/forum?id=iZO7RRZDCC},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1257,7 +1396,8 @@ title={Towards Effective LLM Reasoning for Time Series Classification},
 author={Jiahui Zhou and Dan Li and Wenjie Feng and Lin Li and Jian Lou and See-Kiong Ng},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=4rlzjjSTmg}
+url={https://openreview.net/forum?id=4rlzjjSTmg},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1266,7 +1406,8 @@ title={Towards Evaluating Data Priors for Tabular Foundation Models},
 author={Zeynep Türkmen and Kürşat Kaya and Alexander Pfefferle and Frank Hutter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=GUDjbVGFc1}
+url={https://openreview.net/forum?id=GUDjbVGFc1},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1275,7 +1416,8 @@ title={Towards Pretraining Text Encoders for TabPFN},
 author={Mustafa Tajjar and Alexander Pfefferle and Lennart Purucker and Frank Hutter},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=dA8IZj8R46}
+url={https://openreview.net/forum?id=dA8IZj8R46},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1284,7 +1426,8 @@ title={TradeFM: A Generative Foundation Model for Trade-flow and Market Microstr
 author={Srijan Sood and Maxime Kawawa-Beaudan and Daniel Borrajo and Manuela Veloso},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=anK6dppdfa}
+url={https://openreview.net/forum?id=anK6dppdfa},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1293,7 +1436,8 @@ title={Training Fair Tabular Foundation Models},
 author={Patrik Kenfack and Jesse C. Cresswell and Anthony L. Caterini and Samira Ebrahimi Kahou and Ulrich Aïvodji},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=ajIvCEbadL}
+url={https://openreview.net/forum?id=ajIvCEbadL},
+presentation={oral}
 }
 
 @inproceedings{
@@ -1302,7 +1446,8 @@ title={TSQueryBench: LLM-as-a-Judge for Time-Series Explanations},
 author={Preetham Sivalingam and Murari Mandal and Dhruv Kumar and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=4zY414Cp3v}
+url={https://openreview.net/forum?id=4zY414Cp3v},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1311,7 +1456,8 @@ title={VLM-Guided Noisy Label Detection for Structured Network Traffic in Low-Re
 author={Yuha Jeon and Myung-Sun Baek},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=w82j6qd9Od}
+url={https://openreview.net/forum?id=w82j6qd9Od},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1320,7 +1466,8 @@ title={What You Pretrain On Matters: Synthetic Task Distributions Determine Tabu
 author={Mohamed Bouadi and Nassim Bouarour and Shivam Dubey and Varun Kulkarni and Aditya Tanna and Vinay kumar Sankarapu},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=QfXHxB9VSS}
+url={https://openreview.net/forum?id=QfXHxB9VSS},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1329,7 +1476,8 @@ title={When Data Is Scarce: The Strength of the Prior in Tabular Foundation Mode
 author={Florian D. van Leeuwen and Sara van Erp},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=dznQA3JHfI}
+url={https://openreview.net/forum?id=dznQA3JHfI},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1338,7 +1486,8 @@ title={When Forecasting Fails: Overcoming Temporal Correlation Shift in Time Ser
 author={Chen Shao and Zhenyi ZHU and Tobias Käfer},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=r0rUbOXBUE}
+url={https://openreview.net/forum?id=r0rUbOXBUE},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1347,7 +1496,8 @@ title={When Simpler ICL Outperforms Pretrained Tabular Foundation Models for RNA
 author={Ran Eisenberg and Efraim Rahamim and Erez Levanon and Ofir Lindenbaum},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=enXSrwGxRn}
+url={https://openreview.net/forum?id=enXSrwGxRn},
+presentation={poster}
 }
 
 @inproceedings{
@@ -1356,5 +1506,6 @@ title={Where Computation Lives Inside TabPFN: Causal Localisation of Attention H
 author={Atharva Gupta and Dhruv Kumar and Murari Mandal and Saurabh Deshpande},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},
-url={https://openreview.net/forum?id=LXSawSSeA9}
+url={https://openreview.net/forum?id=LXSawSSeA9},
+presentation={poster}
 }

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2,7 +2,7 @@
 ---
 @inproceedings{
 abolhasani2026plurel,
-title={\plurel-to-\rdbpfn: Schema-Guided Synthetic Relational Pretraining},
+title={{PLuRel}-to-{RDB-PFN}: Schema-Guided Synthetic Relational Pretraining},
 author={Mohammad Sadeq Abolhasani and Viswanath Ganapathy},
 booktitle={2nd ICML Workshop on Foundation Models for Structured Data},
 year={2026},

--- a/_config.yml
+++ b/_config.yml
@@ -325,6 +325,7 @@ filtered_bibtex_keywords:
     inspirehep_id,
     pdf,
     poster,
+    presentation,
     preview,
     selected,
     slides,

--- a/_config.yml
+++ b/_config.yml
@@ -297,6 +297,8 @@ scholar:
   query: "@*"
   group_by: year
   group_order: descending
+  sort_by: title
+  order: ascending
 
 # Display different badges withs stats for your publications
 # Customize badge behavior in _layouts/bib.liquid

--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -251,6 +251,9 @@
       {% if entry.website %}
         <a href="{{ entry.website }}" class="btn btn-sm z-depth-0" role="button">Website</a>
       {% endif %}
+      {% if entry.url and entry.url contains 'openreview.net' %}
+        <a href="{{ entry.url }}" class="btn btn-sm z-depth-0" role="button" target="_blank" rel="noopener noreferrer">OpenReview</a>
+      {% endif %}
     </div>
     {% if site.enable_publication_badges %}
       {% assign entry_has_altmetric_badge = false %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -40,7 +40,7 @@ Please see the [Call for Papers](/call-for-papers/) for details.
 
 ### Schedule
 
-**July 10–11, 2026, Coex Convention & Exhibition Center, Seoul, South Korea**
+**July 11, 2026, 9:00-17:00, Coex Convention & Exhibition Center, Seoul, South Korea**
 
 The workshop will consist of 3 invited talks, 9 industry spotlights, 8 spotlight paper talks, and two poster sessions with contributed papers. You can find the tentative workshop schedule below:
 

--- a/_pages/accepted.md
+++ b/_pages/accepted.md
@@ -7,8 +7,18 @@ nav: true
 nav_order: 2
 ---
 
+## Spotlight Orals
+
 <div class="publications">
 
-{% bibliography %}
+{% bibliography --query "@*[presentation=oral]" %}
+
+</div>
+
+## Posters
+
+<div class="publications">
+
+{% bibliography --query "@*[presentation=poster]" %}
 
 </div>

--- a/_pages/accepted.md
+++ b/_pages/accepted.md
@@ -11,7 +11,7 @@ nav_order: 2
 
 <div class="publications">
 
-{% bibliography --query "@*[presentation=oral]" %}
+{% bibliography -q @*[presentation=oral] %}
 
 </div>
 
@@ -19,6 +19,6 @@ nav_order: 2
 
 <div class="publications">
 
-{% bibliography --query "@*[presentation=poster]" %}
+{% bibliography -q @*[presentation=poster] %}
 
 </div>

--- a/_pages/accepted.md
+++ b/_pages/accepted.md
@@ -7,6 +7,8 @@ nav: true
 nav_order: 2
 ---
 
-## Accepted Papers
+<div class="publications">
 
-To be announced.
+{% bibliography %}
+
+</div>

--- a/scripts/generate_accepted.py
+++ b/scripts/generate_accepted.py
@@ -1,0 +1,246 @@
+"""
+Generate ``_bibliography/papers.bib`` for the FMSD workshop website
+from an OpenReview submissions CSV export.
+
+Reads ``submissions.csv`` (OpenReview export), drops rejected papers, and
+emits a BibTeX file with one ``@inproceedings`` entry per accepted paper.
+Author names are resolved by querying the OpenReview API (v2) for each
+paper's forum note.
+
+Usage:
+    python scripts/generate_accepted.py \
+        [--csv submissions.csv] \
+        [--out _bibliography/papers.bib] \
+        [--username USER] [--password PW]
+
+Credentials may also be supplied via the ``OPENREVIEW_USERNAME`` /
+``OPENREVIEW_PASSWORD`` environment variables. Anonymous access works
+only for public venues; FMSD submissions typically require a logged-in
+PC/organizer account.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import getpass
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import openreview  # noqa: F401  (ensures the package is importable up-front)
+import openreview.api
+
+
+# Decision strings as they appear in the OpenReview CSV export.
+SPOTLIGHT_DECISION = "Accept (Spotlight Oral)"
+POSTER_DECISION = "Accept (Poster)"
+ACCEPT_DECISIONS = {SPOTLIGHT_DECISION, POSTER_DECISION}
+
+# Booktitle used for every entry — matches the convention in papers-2025.bib.
+BOOKTITLE = "2nd ICML Workshop on Foundation Models for Structured Data"
+YEAR = "2026"
+
+OPENREVIEW_API2 = "https://api2.openreview.net"
+
+
+def load_accepted(csv_path: Path) -> list[dict]:
+    """Read the CSV and return only accepted rows."""
+    # ``utf-8-sig`` strips the BOM that OpenReview includes on the header line.
+    with csv_path.open(newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        return [row for row in reader if row["decision"] in ACCEPT_DECISIONS]
+
+
+def extract_forum_id(forum_url: str) -> str:
+    """Extract the ``id=...`` parameter from an OpenReview forum URL."""
+    parsed = urlparse(forum_url.strip())
+    qs = parse_qs(parsed.query)
+    if "id" not in qs or not qs["id"]:
+        raise ValueError(f"could not parse forum id from URL: {forum_url!r}")
+    return qs["id"][0]
+
+
+def make_client(username: str | None, password: str | None) -> openreview.api.OpenReviewClient:
+    """Create an OpenReview API v2 client, optionally authenticated."""
+    return openreview.api.OpenReviewClient(
+        baseurl=OPENREVIEW_API2,
+        username=username,
+        password=password,
+    )
+
+
+def _content_value(content: dict, key: str):
+    """Return the value of a note content field, handling v1/v2 shapes."""
+    if key not in content:
+        return None
+    field = content[key]
+    # API v2 wraps values in {"value": ...}; API v1 stores them directly.
+    if isinstance(field, dict) and "value" in field:
+        return field["value"]
+    return field
+
+
+def fetch_authors(client: openreview.api.OpenReviewClient, forum_id: str) -> list[str]:
+    """Return the list of author names for an OpenReview forum note."""
+    note = client.get_note(forum_id)
+    authors = _content_value(note.content, "authors")
+    if not authors:
+        raise RuntimeError(f"no authors found for forum {forum_id}")
+    if isinstance(authors, str):
+        # Defensive: occasionally a single author may come back as a string.
+        authors = [authors]
+    return list(authors)
+
+
+def make_citekey(first_author: str, title: str, year: str, used: set[str]) -> str:
+    """Build a stable BibTeX citation key, deduplicating against ``used``."""
+    last = first_author.strip().split()[-1] if first_author.strip() else "anon"
+    last = re.sub(r"[^A-Za-z]", "", last).lower() or "anon"
+    first_word = ""
+    for word in re.findall(r"[A-Za-z]+", title):
+        if word.lower() in {"a", "an", "the", "on", "of", "for", "to", "in", "and", "or"}:
+            continue
+        first_word = word.lower()
+        break
+    base = f"{last}{year}{first_word}" if first_word else f"{last}{year}"
+    key = base
+    n = 2
+    while key in used:
+        key = f"{base}{n}"
+        n += 1
+    used.add(key)
+    return key
+
+
+# Characters that need escaping inside a brace-delimited BibTeX field.
+_BRACE_RE = re.compile(r"([{}])")
+
+
+def bib_escape(value: str) -> str:
+    """Escape a value for inclusion inside ``{...}`` in a BibTeX field.
+
+    We deliberately keep this minimal: OpenReview titles and author names
+    are already plain Unicode, which biblatex / jekyll-scholar handle fine.
+    We only protect against unbalanced braces and strip surrounding
+    whitespace.
+    """
+    return _BRACE_RE.sub(r"\\\1", value).strip()
+
+
+def render_entry(citekey: str, title: str, authors: list[str], forum_url: str) -> str:
+    """Render a single ``@inproceedings`` entry, matching the 2025 style."""
+    author_field = " and ".join(bib_escape(a) for a in authors)
+    return (
+        f"@inproceedings{{\n"
+        f"{citekey},\n"
+        f"title={{{bib_escape(title)}}},\n"
+        f"author={{{author_field}}},\n"
+        f"booktitle={{{BOOKTITLE}}},\n"
+        f"year={{{YEAR}}},\n"
+        f"url={{{forum_url.strip()}}}\n"
+        f"}}\n"
+    )
+
+
+def render_bib(entries: list[str]) -> str:
+    """Wrap the entries in the YAML front matter required by jekyll-scholar."""
+    return "---\n---\n" + "\n".join(entries)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=Path("submissions.csv"),
+        help="Path to the OpenReview submissions CSV (default: submissions.csv).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("_bibliography/papers.bib"),
+        help="Output BibTeX file (default: _bibliography/papers.bib).",
+    )
+    parser.add_argument(
+        "--username",
+        default=os.environ.get("OPENREVIEW_USERNAME"),
+        help="OpenReview username (default: $OPENREVIEW_USERNAME).",
+    )
+    parser.add_argument(
+        "--password",
+        default=os.environ.get("OPENREVIEW_PASSWORD"),
+        help="OpenReview password (default: $OPENREVIEW_PASSWORD).",
+    )
+    parser.add_argument(
+        "--prompt-password",
+        action="store_true",
+        help="Prompt for the OpenReview password interactively.",
+    )
+    args = parser.parse_args()
+
+    if not args.csv.is_file():
+        print(f"error: CSV file not found: {args.csv}", file=sys.stderr)
+        return 1
+
+    if args.prompt_password and not args.password:
+        args.password = getpass.getpass("OpenReview password: ")
+
+    if args.username and not args.password:
+        print(
+            "error: --username given but no password (set $OPENREVIEW_PASSWORD "
+            "or pass --password / --prompt-password).",
+            file=sys.stderr,
+        )
+        return 1
+
+    rows = load_accepted(args.csv)
+    n_spot = sum(1 for r in rows if r["decision"] == SPOTLIGHT_DECISION)
+    n_post = sum(1 for r in rows if r["decision"] == POSTER_DECISION)
+    print(
+        f"Found {len(rows)} accepted papers "
+        f"({n_spot} spotlight oral, {n_post} poster).",
+        file=sys.stderr,
+    )
+    if not rows:
+        print("warning: no accepted papers — writing an empty .bib file.", file=sys.stderr)
+
+    client = make_client(args.username, args.password)
+
+    # Sort by title for stable output, matching the on-page ordering.
+    rows = sorted(rows, key=lambda r: r["title"].strip().lower())
+
+    entries: list[str] = []
+    used_keys: set[str] = set()
+    failures: list[tuple[str, str]] = []
+    for row in rows:
+        title = row["title"].strip()
+        forum_url = row["forum"].strip()
+        try:
+            forum_id = extract_forum_id(forum_url)
+            authors = fetch_authors(client, forum_id)
+        except Exception as exc:  # noqa: BLE001 — surface any API/parse error
+            print(f"  ! {title!r}: {exc}", file=sys.stderr)
+            failures.append((title, str(exc)))
+            continue
+
+        citekey = make_citekey(authors[0], title, YEAR, used_keys)
+        entries.append(render_entry(citekey, title, authors, forum_url))
+        print(f"  ✓ {citekey}: {len(authors)} author(s)", file=sys.stderr)
+
+    output = render_bib(entries)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(output, encoding="utf-8")
+    print(
+        f"Wrote {len(entries)} entries to {args.out}"
+        + (f" ({len(failures)} failed)" if failures else ""),
+        file=sys.stderr,
+    )
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate_accepted.py
+++ b/scripts/generate_accepted.py
@@ -130,8 +130,13 @@ def bib_escape(value: str) -> str:
     return _BRACE_RE.sub(r"\\\1", value).strip()
 
 
-def render_entry(citekey: str, title: str, authors: list[str], forum_url: str) -> str:
-    """Render a single ``@inproceedings`` entry, matching the 2025 style."""
+def render_entry(citekey: str, title: str, authors: list[str], forum_url: str, presentation: str) -> str:
+    """Render a single ``@inproceedings`` entry, matching the 2025 style.
+
+    ``presentation`` is a non-standard BibTeX field (``oral`` or ``poster``)
+    used by ``_pages/accepted.md`` to split the bibliography into two
+    sections via jekyll-scholar's ``--query "@*[presentation=...]"`` filter.
+    """
     author_field = " and ".join(bib_escape(a) for a in authors)
     return (
         f"@inproceedings{{\n"
@@ -140,7 +145,8 @@ def render_entry(citekey: str, title: str, authors: list[str], forum_url: str) -
         f"author={{{author_field}}},\n"
         f"booktitle={{{BOOKTITLE}}},\n"
         f"year={{{YEAR}}},\n"
-        f"url={{{forum_url.strip()}}}\n"
+        f"url={{{forum_url.strip()}}},\n"
+        f"presentation={{{presentation}}}\n"
         f"}}\n"
     )
 
@@ -227,8 +233,9 @@ def main() -> int:
             continue
 
         citekey = make_citekey(authors[0], title, YEAR, used_keys)
-        entries.append(render_entry(citekey, title, authors, forum_url))
-        print(f"  ✓ {citekey}: {len(authors)} author(s)", file=sys.stderr)
+        presentation = "oral" if row["decision"] == SPOTLIGHT_DECISION else "poster"
+        entries.append(render_entry(citekey, title, authors, forum_url, presentation))
+        print(f"  ✓ {citekey} ({presentation}): {len(authors)} author(s)", file=sys.stderr)
 
     output = render_bib(entries)
     args.out.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Adds script to create up-to-date list of accepted papers.
 - Updates accepted papers page for 2026

Double-checked locally and it renders fine.